### PR TITLE
Add CI for mingw-w64 with MSYS2

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -12,29 +12,59 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
-      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
-      fail-fast: false
 
-      # Set up a matrix to run the following 3 configurations:
+      # Set up a matrix to run the following configurations:
       # 1. <Windows, Release, latest MSVC compiler toolchain on the default runner image, default generator>
       # 2. <Linux, Release, latest GCC compiler toolchain on the default runner image, default generator>
       # 3. <Linux, Release, latest Clang compiler toolchain on the default runner image, default generator>
+      # 4. <Windows, Release, MSYS2 MINGW64 GCC compiler>
+      # 5. <Windows, Release, MSYS2 MINGW64 Clang compiler>
+      # 6. <Windows, Release, MSYS2 UCRT64 GCC compiler>
+      # 7. <Windows, Release, MSYS2 UCRT64 Clang compiler>
+      # 8. <Windows, Release, MSYS2 CLANG64 Clang compiler>
       #
-      # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
         os: [ubuntu-latest, windows-latest]
         build_type: [Release]
         c_compiler: [gcc, clang, cl]
         include:
+          # Windows MSVC
           - os: windows-latest
             c_compiler: cl
             cpp_compiler: cl
+          # Ubuntu GCC
           - os: ubuntu-latest
             c_compiler: gcc
             cpp_compiler: g++
+          # Ubuntu clang
           - os: ubuntu-latest
             c_compiler: clang
             cpp_compiler: clang++
+          # MSYS2 MINGW64 + GCC
+          - os: windows-latest
+            c_compiler: gcc
+            cpp_compiler: g++
+            msys2_env: MINGW64
+          # MSYS2 MINGW64 + Clang
+          - os: windows-latest
+            c_compiler: clang
+            cpp_compiler: clang++
+            msys2_env: MINGW64
+          # MSYS2 UCRT64 + GCC
+          - os: windows-latest
+            c_compiler: gcc
+            cpp_compiler: g++
+            msys2_env: UCRT64
+          # MSYS2 UCRT64 + Clang
+          - os: windows-latest
+            c_compiler: clang
+            cpp_compiler: clang++
+            msys2_env: UCRT64
+          # MSYS2 CLANG64 + Clang
+          - os: windows-latest
+            c_compiler: clang
+            cpp_compiler: clang++
+            msys2_env: CLANG64
         exclude:
           - os: windows-latest
             c_compiler: gcc
@@ -46,6 +76,34 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Setup MSYS2 (GCC)
+      if: matrix.msys2_env && matrix.c_compiler == 'gcc'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{ matrix.msys2_env }}
+        update: true
+        install: >-
+          base-devel
+          git
+        pacboy: >-
+          toolchain:p
+          cmake:p
+          ninja:p
+
+    - name: Setup MSYS2 (Clang)
+      if: matrix.msys2_env && matrix.c_compiler == 'clang'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{ matrix.msys2_env }}
+        update: true
+        install: >-
+          base-devel
+          git
+        pacboy: >-
+          clang:p
+          cmake:p
+          ninja:p
+
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
       id: strings
@@ -53,9 +111,29 @@ jobs:
       run: |
         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+    - name: Set MSYS2 paths
+      if: matrix.msys2_env
+      id: msys2_strings
+      shell: msys2 {0}
+      run: |
+        echo "build-output-dir=$(cygpath -u '${{ github.workspace }}')/build" >> "$GITHUB_OUTPUT"
+        echo "source-dir=$(cygpath -u '${{ github.workspace }}')" >> "$GITHUB_OUTPUT"
+
+    - name: Configure CMake (MSYS2)
+      if: matrix.msys2_env
+      shell: msys2 {0}
+      run: >
+        cmake -B ${{ steps.msys2_strings.outputs.build-output-dir }}
+        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
+        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DWGVK_USE_VMA=ON
+        -DWGVK_BUILD_WGSL_SUPPORT=ON
+        -DWGVK_BUILD_GLSL_SUPPORT=ON
+        -S ${{ steps.msys2_strings.outputs.source-dir }}
+
+    - name: Configure CMake (Regular)
+      if: '!matrix.msys2_env'
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
@@ -66,11 +144,23 @@ jobs:
         -DWGVK_BUILD_GLSL_SUPPORT=ON
         -S ${{ github.workspace }}
 
-    - name: Build
-      # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
-      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+    - name: Build (MSYS2)
+      if: matrix.msys2_env
+      shell: msys2 {0}
+      run: cmake --build ${{ steps.msys2_strings.outputs.build-output-dir }} --parallel 4
 
-    - name: Test
+    - name: Build (Regular)
+      if: '!matrix.msys2_env'
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }} --parallel 4
+
+    - name: Test (MSYS2)
+      if: matrix.msys2_env
+      working-directory: ${{ steps.strings.outputs.build-output-dir }}
+      shell: msys2 {0}
+      run: ctest
+
+    - name: Test (Regular)
+      if: '!matrix.msys2_env'
       working-directory: ${{ steps.strings.outputs.build-output-dir }}
       # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail


### PR DESCRIPTION
This PR adds CI builds for the following matrix:

|       | mingw64 | ucrt64 | clang64 | clangarm64 |
| ----- | ------- | ------ | ------- | ---------- |
| clang | X       | X      | X       |            |
| gcc   | X       | X      |         |            |

I could not get clangarm64 to work, that can be figured later.