### PR TITLE
Fix windows macro redefined warnings

### DIFF
--- a/include/wgvk_structs_impl.h
+++ b/include/wgvk_structs_impl.h
@@ -77,9 +77,6 @@
 #if defined(_WIN32)
     #define WIN32_LEAN_AND_MEAN
     #define Rectangle w__Rectangle
-    #define LoadImage w__LoadImage
-    #define DrawText w__DrawText
-    #define DrawTextEx w__DrawTextEx
     #define ShowCursor w__ShowCursor
     #define AdapterType w__AdapterType
     #include <windows.h>


### PR DESCRIPTION
When building for windows, warnings about redefining macros were emitted

Since these are already macros, there is no point to define something
different to rename them first.

In file included from C:\programming\homedir\WGVK\src\wgvk.c:96:
C:/programming/homedir/WGVK/include/wgvk_structs_impl.h:80:13: warning: 'LoadImage' redefined
   80 |     #define LoadImage w__LoadImage
      |             ^~~~~~~~~
In file included from C:/programming/toolchains/w64devkit/include/windows.h:72,
                 from C:\programming\homedir\WGVK\src\wgvk.c:71:
C:/programming/toolchains/w64devkit/include/winuser.h:4201:9: note: this is the location of the previous definition
 4201 | #define LoadImage __MINGW_NAME_AW(LoadImage)
      |         ^~~~~~~~~
C:/programming/homedir/WGVK/include/wgvk_structs_impl.h:81:13: warning: 'DrawText' redefined
   81 |     #define DrawText w__DrawText
      |             ^~~~~~~~
C:/programming/toolchains/w64devkit/include/winuser.h:3477:9: note: this is the location of the previous definition
 3477 | #define DrawText __MINGW_NAME_AW(DrawText)
      |         ^~~~~~~~
C:/programming/homedir/WGVK/include/wgvk_structs_impl.h:82:13: warning: 'DrawTextEx' redefined
   82 |     #define DrawTextEx w__DrawTextEx
      |             ^~~~~~~~~~
C:/programming/toolchains/w64devkit/include/winuser.h:3478:9: note: this is the location of the previous definition
 3478 | #define DrawTextEx __MINGW_NAME_AW(DrawTextEx)
      |         ^~~~~~~~~~
