### PR TITLE
Add /Zc:preprocessor flag for MSVC to fix __VA_OPT__ errors in Dawn/Tint build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ if(WGVK_BUILD_WGSL_SUPPORT)
     $<$<CXX_COMPILER_ID:GNU>:-fno-rtti>
     $<$<CXX_COMPILER_ID:Clang>:-fno-rtti>
     $<$<CXX_COMPILER_ID:AppleClang>:-fno-rtti>
+    $<$<CXX_COMPILER_ID:MSVC>:/Zc:preprocessor>
     $<$<CXX_COMPILER_ID:MSVC>:/GR->  # disable RTTI in MSVC
   )
   target_compile_definitions(${WGVK_PRIMARY_TARGET_NAME} PUBLIC SUPPORT_WGSL=1)


### PR DESCRIPTION
The MSVC CI was failing likeso:
```
D:\a\WGVK\WGVK\build\_deps\dawn-src\src\tint\utils\containers\slice.h(237,9): warning C5109: __VA_OPT__ use in macro requires '/Zc:preprocessor' [D:\a\WGVK\WGVK\build\tint_c_api.vcxproj]
  (compiling source file '../src/tint_c_api.cpp')
      D:\a\WGVK\WGVK\build\_deps\dawn-src\src\tint\utils\ice\ice.h(120,9):
      in expansion of macro 'TINT_ASSERT'
  ```

https://learn.microsoft.com/en-us/cpp/build/reference/zc-preprocessor?view=msvc-170
MSVC has an opt-in flag to enable a c99 compatible preprocessor. It's not default.
Another cl.exe classic!