### PR TITLE
Prevent failing CI runs from cancelling the rest

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
 
       # Set up a matrix to run the following configurations:
       # 1. <Windows, Release, latest MSVC compiler toolchain on the default runner image, default generator>


### PR DESCRIPTION
fast-fail means that if one job fails it will immediately cancel the rest of them. Turn that off, we don't want it.