### PR TITLE
Disable OpenGL context creation in GLFW

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -89,8 +89,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
-        sudo apt-get install -y wayland-protocols libwayland-dev libxkbcommon-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl1-mesa-dev
-
+        sudo apt-get install -y wayland-protocols libwayland-dev libxkbcommon-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
     - name: Setup MSYS2 (GCC)
       if: matrix.msys2_env && matrix.c_compiler == 'gcc'
       uses: msys2/setup-msys2@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,15 @@ endif()
 
 if(WGVK_BUILD_EXAMPLES)
   if(NOT EMSCRIPTEN)
+    # Disable OpenGL support completely in GLFW
+    set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
+    set(GLFW_INSTALL OFF CACHE BOOL "" FORCE)
+    set(GLFW_CLIENT_LIBRARY "none" CACHE STRING "" FORCE)
+    # Prevent GLFW headers from including OpenGL headers
+    set(GLFW_INCLUDE_NONE ON CACHE BOOL "" FORCE)
+    
     FetchContent_Declare(
       glfw
       URL https://github.com/glfw/glfw/archive/refs/tags/3.4.tar.gz

--- a/examples/common.h
+++ b/examples/common.h
@@ -1,5 +1,6 @@
 #ifndef COMMON_H_
 #define COMMON_H_
+#define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
 #include <stdio.h>
 #include <webgpu/webgpu.h>

--- a/examples/glfw_surface.c
+++ b/examples/glfw_surface.c
@@ -1,3 +1,4 @@
+#define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
 #ifdef __EMSCRIPTEN__
     #include <webgpu/webgpu.h>


### PR DESCRIPTION
In #19 I made the CI install the opengl headers and libraries despite that we don't actually use them.
This PR basically disables all opengl support in the vendored GLFW so it only supports window creation.