### PR TITLE
fix atomic arg order

### DIFF
--- a/src/wgvk.c
+++ b/src/wgvk.c
@@ -7187,7 +7187,7 @@ void wgpuRaytracingPassEncoderEnd(WGPURaytracingPassEncoder rtPassEncoder){
 void wgpuFenceReset(WGPUFence fence){
     wgvk_assert(atomic_load_explicit(&fence->state, memory_order_acquire) == WGPUFenceState_Finished, "Fence must be finished");
     fence->device->functions.vkResetFences(fence->device->device, 1, &fence->fence);
-    atomic_store_explicit(&fence->state, memory_order_release, WGPUFenceState_Reset);
+    atomic_store_explicit(&fence->state, WGPUFenceState_Reset, memory_order_release);
 }
 
 

--- a/src/wgvk.c
+++ b/src/wgvk.c
@@ -2641,7 +2641,7 @@ WGPUFuture wgpuAdapterRequestDevice(WGPUAdapter adapter, WGPU_NULLABLE WGPUDevic
     userdata->adapter = adapter;
     userdata->callbackInfo = callbackInfo;
     if(options)
-    userdata->deviceDescriptor = *options;
+        userdata->deviceDescriptor = *options;
     WGPUFutureImpl impl = {
         .userdataForFunction = userdata,
         .functionCalledOnWaitAny = wgpuAdapterCreateDevice_sync,


### PR DESCRIPTION
```c
void atomic_store_explicit( volatile A* obj, C desired, memory_order order );
```

```c
wgvk.c: In function ‘wgpuFenceReset’:
wgvk.c:7190:5: warning: implicit conversion from ‘enum <anonymous>’ to ‘WGPUFenceState’ [-Wenum-conversion]
 7190 |     atomic_store_explicit(&fence->state, memory_order_release, WGPUFenceState_Reset);
      |     ^~~~~~~~~~~~~~~~~~~~~
```

Found warning with gcc -Wextra (clang doesn't warn) which is also UB. https://en.cppreference.com/w/c/atomic/atomic_store.html