### PR TITLE
fix: align wgvk.h depth/queue/callback types with the WebGPU spec

### DIFF
--- a/include/wgvk.h
+++ b/include/wgvk.h
@@ -408,11 +408,11 @@ typedef enum WGPUPolygonMode {
     WGPUPolygonMode_Force32 = 0x7FFFFFFF
 } WGPUPolygonMode WGPU_ENUM_ATTRIBUTE;
 
-typedef enum WGPUVertexStepMode { 
-    WGPUVertexStepMode_Undefined = 0x0, 
+typedef enum WGPUVertexStepMode {
+    WGPUVertexStepMode_Undefined = 0x0,
     WGPUVertexStepMode_Vertex = 0x1,
     WGPUVertexStepMode_Instance = 0x2,
-    WGPUVertexStepMode_Force32 = 0x7FFFFFFF 
+    WGPUVertexStepMode_Force32 = 0x7FFFFFFF
 } WGPUVertexStepMode;
 
 typedef enum WGPUIndexFormat {
@@ -910,7 +910,7 @@ typedef void (*WGPUCompilationInfoCallback)(WGPUCompilationInfoRequestStatus sta
 typedef void (*WGPUCreateComputePipelineAsyncCallback)(WGPUCreatePipelineAsyncStatus status, WGPUComputePipeline pipeline, WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUCreateRenderPipelineAsyncCallback)(WGPUCreatePipelineAsyncStatus status, WGPURenderPipeline pipeline, WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUPopErrorScopeCallback)(WGPUPopErrorScopeStatus status, WGPUErrorType type, WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
-typedef void (*WGPUQueueWorkDoneCallback)(WGPUQueueWorkDoneStatus status, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUQueueWorkDoneCallback)(WGPUQueueWorkDoneStatus status, WGPUStringView message, WGPU_NULLABLE void* userdata1, WGPU_NULLABLE void* userdata2) WGPU_FUNCTION_ATTRIBUTE;
 
 // Missing Structs
 typedef struct WGPUCompilationInfoCallbackInfo {
@@ -1136,9 +1136,9 @@ typedef struct WGPUSurfaceSourceDrmPlane {
     uint32_t  crtcId;
     uint32_t  planeId;
 
-    
+
     WGPUDrmModeSelect modeSelect;
-    
+
     WGPUBool acquireExclusive;
 } WGPUSurfaceSourceDrmPlane;
 
@@ -1328,7 +1328,7 @@ typedef void (*WGPUUncapturedErrorCallback)(const WGPUDevice*, WGPUErrorType, st
 
 typedef struct WGPUDeviceLostCallbackInfo {
     WGPUChainedStruct * nextInChain;
-    int mode;
+    WGPUCallbackMode mode;
     WGPUDeviceLostCallback callback;
     void* userdata1;
     void* userdata2;
@@ -1682,9 +1682,9 @@ typedef struct WGPUStencilFaceState {
 typedef struct WGPUDepthStencilState {
     WGPUChainedStruct* nextInChain;
     WGPUTextureFormat format;
-    WGPUBool32 depthWriteEnabled;
+    WGPUOptionalBool depthWriteEnabled;
     WGPUCompareFunction depthCompare;
-    
+
     WGPUStencilFaceState stencilFront;
     WGPUStencilFaceState stencilBack;
     uint32_t stencilReadMask;
@@ -2029,7 +2029,7 @@ WGVK_EXPORT void wgpuRaytracingPassEncoderEnd(WGPURaytracingPassEncoder commandE
 WGVK_EXPORT WGPUComputePassEncoder wgpuCommandEncoderBeginComputePass(WGPUCommandEncoder enc, const WGPUComputePassDescriptor* cpdesc);
 WGVK_EXPORT void wgpuComputePassEncoderEnd(WGPUComputePassEncoder commandEncoder);
 WGVK_EXPORT WGPURenderPassEncoder wgpuCommandEncoderBeginRenderPass(WGPUCommandEncoder enc, const WGPURenderPassDescriptor* rpdesc);
-    
+
 WGVK_EXPORT void wgpuCommandEncoderBuildRayTracingAccelerationContainer(WGPUCommandEncoder encoder, WGPURayTracingAccelerationContainer container);
 WGVK_EXPORT void wgpuCommandEncoderCopyRayTracingAccelerationContainer(WGPUCommandEncoder encoder, WGPURayTracingAccelerationContainer source, WGPURayTracingAccelerationContainer dest);
 WGVK_EXPORT void wgpuCommandEncoderUpdateRayTracingAccelerationContainer(WGPUCommandEncoder encoder, WGPURayTracingAccelerationContainer container);

--- a/src/wgvk.c
+++ b/src/wgvk.c
@@ -1,20 +1,20 @@
 /*
  * MIT License
- * 
+ *
  * wgvk.c - A single file WebGPU implementation in C11
- * 
+ *
  * Copyright (c) 2025 @manuel5975p
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -200,7 +200,7 @@ const char* vkErrorString(int code);
 
 
 static inline uint32_t findMemoryType(WGPUAdapter adapter, uint32_t typeFilter, VkMemoryPropertyFlags properties) {
-    
+
     if(adapter->memProperties.memoryTypeCount == 0){
         vkGetPhysicalDeviceMemoryProperties(adapter->physicalDevice, &adapter->memProperties);
     }
@@ -216,7 +216,7 @@ static inline uint32_t findMemoryType(WGPUAdapter adapter, uint32_t typeFilter, 
 
 static void doSurfaceCreation(WGPUInstance instance, WGPUSurface ret, WGPUChainedStruct* descriptor){
     switch(descriptor->sType){
-        default: 
+        default:
         wgvk_assert(false, "Unsupported surface SType");
         return;
         #if SUPPORT_METAL_SURFACE == 1
@@ -336,7 +336,7 @@ static void doSurfaceCreation(WGPUInstance instance, WGPUSurface ret, WGPUChaine
                     vkGetPhysicalDeviceProperties2(phys, &p2);
                 }
                 VkDisplayKHR display = VK_NULL_HANDLE;
-                
+
                 if (vkGetDrmDisplayEXT) {
                     VkResult getDrmDisplayResult = vkGetDrmDisplayEXT(phys, drm->drmFd, drm->connectorId, &display);
                     if (getDrmDisplayResult != VK_SUCCESS) {
@@ -376,7 +376,7 @@ static void doSurfaceCreation(WGPUInstance instance, WGPUSurface ret, WGPUChaine
                     ret->surface = VK_NULL_HANDLE;
                     return;
                 }
-            
+
                 uint32_t chosenModeIndex = 0;
                 if (drm->modeSelect.type == WGPUDrmModeSelect_ByIndex) {
 
@@ -386,12 +386,12 @@ static void doSurfaceCreation(WGPUInstance instance, WGPUSurface ret, WGPUChaine
                     uint32_t targetW  = drm->modeSelect.geometry.width;
                     uint32_t targetH  = drm->modeSelect.geometry.height;
                     uint32_t targetHz = drm->modeSelect.geometry.refreshMilliHz;
-                
+
                     uint32_t i;
                     uint32_t best = 0;
                     uint32_t bestRefreshDiff = 0xFFFFFFFFu;
                     int foundExactWH = 0;
-                
+
                     for (i = 0; i < modeCount && i < 64; ++i) {
                         const VkDisplayModeParametersKHR* p = &modeProps[i].parameters;
                         if (p->visibleRegion.width == targetW && p->visibleRegion.height == targetH) {
@@ -409,10 +409,10 @@ static void doSurfaceCreation(WGPUInstance instance, WGPUSurface ret, WGPUChaine
                     }
                     chosenModeIndex = foundExactWH ? best : 0;
                 }
-            
+
                 VkDisplayModeKHR displayMode = modeProps[chosenModeIndex].displayMode;
                 VkDisplayModeParametersKHR modeParams = modeProps[chosenModeIndex].parameters;
-            
+
                 /* --- Step 3: Pick a display plane that supports this display --- */
                 uint32_t planeCount = 64;
                 VkDisplayPlanePropertiesKHR planeProps[64] = {0};
@@ -420,9 +420,9 @@ static void doSurfaceCreation(WGPUInstance instance, WGPUSurface ret, WGPUChaine
                     planeCount == 0) {
                     break;
                 }
-            
+
                 uint32_t chosenPlane = 0xFFFFFFFFu;
-            
+
                 /* Treat drm->planeId as an index hint */
                 if (drm->planeId < planeCount) {
                     uint32_t supportedCount = 64;
@@ -435,7 +435,7 @@ static void doSurfaceCreation(WGPUInstance instance, WGPUSurface ret, WGPUChaine
                         }
                     }
                 }
-            
+
                 if (chosenPlane == 0xFFFFFFFFu) {
                     uint32_t i;
                     for (i = 0; i < planeCount && i < 64; ++i) {
@@ -454,12 +454,12 @@ static void doSurfaceCreation(WGPUInstance instance, WGPUSurface ret, WGPUChaine
                         if (chosenPlane != 0xFFFFFFFFu) break;
                     }
                 }
-            
+
                 if (chosenPlane == 0xFFFFFFFFu) {
                     wgvk_assert(false, "No plane supports the display");
                     break; /* No plane supports the display */
                 }
-            
+
                 VkDisplayPlaneCapabilities2KHR caps = {
                     .sType = VK_STRUCTURE_TYPE_DISPLAY_PLANE_CAPABILITIES_2_KHR
                 };
@@ -543,15 +543,15 @@ WGPUSurface wgpuInstanceCreateSurface(WGPUInstance instance, const WGPUSurfaceDe
 
 char* sw_sprintf(const char* format, ...) {
     if (!format) return NULL;
-    
+
     va_list args1, args2;
     va_start(args1, format);
     va_copy(args2, args1);
-    
+
     // Calculate required buffer size by processing format string
     size_t total_len = 0;
     const char* p = format;
-    
+
     while (*p) {
         if (*p == '%') {
             p++;
@@ -560,7 +560,7 @@ char* sw_sprintf(const char* format, ...) {
                 p++;
                 continue;
             }
-            
+
             // Skip flags, width, precision
             while (*p && strchr("-+ #0", *p)) p++;
             while (*p && *p >= '0' && *p <= '9') p++;
@@ -568,7 +568,7 @@ char* sw_sprintf(const char* format, ...) {
                 p++;
                 while (*p && *p >= '0' && *p <= '9') p++;
             }
-            
+
             // Check for our custom specifier
             if (*p == 's' && p[1] == 'w') {
                 WGPUStringView sv = va_arg(args1, WGPUStringView);
@@ -616,20 +616,20 @@ char* sw_sprintf(const char* format, ...) {
             p++;
         }
     }
-    
+
     va_end(args1);
-    
+
     // Allocate buffer with some padding for safety
     char* buffer = RL_MALLOC(total_len + 16);
     if (!buffer) {
         va_end(args2);
         return NULL;
     }
-    
+
     // Build the actual string
     char* out = buffer;
     p = format;
-    
+
     while (*p) {
         if (*p == '%') {
             p++;
@@ -638,10 +638,10 @@ char* sw_sprintf(const char* format, ...) {
                 p++;
                 continue;
             }
-            
+
             // Parse format specifier
             const char* spec_start = p - 1;
-            
+
             // Skip flags, width, precision
             while (*p && strchr("-+ #0", *p)) p++;
             while (*p && *p >= '0' && *p <= '9') p++;
@@ -649,7 +649,7 @@ char* sw_sprintf(const char* format, ...) {
                 p++;
                 while (*p && *p >= '0' && *p <= '9') p++;
             }
-            
+
             if (*p == 's' && p[1] == 'w') {
                 // Handle %sw specifier
                 WGPUStringView sv = va_arg(args2, WGPUStringView);
@@ -670,10 +670,10 @@ char* sw_sprintf(const char* format, ...) {
                 if (spec_len < sizeof(temp_format)) {
                     memcpy(temp_format, spec_start, spec_len);
                     temp_format[spec_len] = '\0';
-                    
+
                     char temp_buf[256];
                     int written = 0;
-                    
+
                     switch (*p) {
                         case 'd': case 'i': case 'o': case 'x': case 'X': case 'u':
                             written = sprintf(temp_buf, temp_format, va_arg(args2, int));
@@ -690,10 +690,10 @@ char* sw_sprintf(const char* format, ...) {
                         case 'p':
                             written = sprintf(temp_buf, temp_format, va_arg(args2, void*));
                             break;
-                        default: 
+                        default:
                             break;
                     }
-                    
+
                     if (written > 0) {
                         memcpy(out, temp_buf, written);
                         out += written;
@@ -705,10 +705,10 @@ char* sw_sprintf(const char* format, ...) {
             *out++ = *p++;
         }
     }
-    
+
     *out = '\0';
     va_end(args2);
-    
+
     // Resize buffer to exact size needed
     size_t actual_len = out - buffer;
     char* final_buffer = realloc(buffer, actual_len + 1);
@@ -765,7 +765,7 @@ WGPUStatus wgpuAdapterGetLimits(WGPUAdapter adapter, WGPULimits* limits) WGPU_FU
     limits->maxComputeWorkgroupSizeZ = deviceProperties2->properties.limits.maxComputeWorkGroupSize[2];
     limits->maxComputeWorkgroupsPerDimension = MIN(deviceProperties2->properties.limits.maxComputeWorkGroupCount[0], MIN(deviceProperties2->properties.limits.maxComputeWorkGroupCount[1], deviceProperties2->properties.limits.maxComputeWorkGroupCount[2]));
     limits->maxImmediateSize = deviceProperties2->properties.limits.maxPushConstantsSize;
-    
+
     WGPUChainedStruct* chain = limits->nextInChain;
     while (chain) {
         if (chain->sType == WGPUSType_ExtrasLimits) {
@@ -834,7 +834,7 @@ void PerframeCache_pushFenceDependencies(PerframeCache* pfcache, WGPUFence fence
 WGPUStatus FIFCache_init(FIFCache* fifCache, WGPUDevice device, uint32_t queueFamily){
     fifCache->device = device;
     VkSemaphoreCreateInfo sci = { VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO };
-    VkCommandPoolCreateInfo pci = { 
+    VkCommandPoolCreateInfo pci = {
         .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
         .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
         .queueFamilyIndex = queueFamily
@@ -927,7 +927,7 @@ void FIFCache_destroy(FIFCache* fcache){
         device->functions.vkDestroySemaphore(device->device, cache->finalTransitionSemaphore, NULL);
         SyncState_destroy(fcache->device, &fcache->frameCaches[i].syncState);
         wgpuFenceRelease(cache->finalTransitionFence);
-        
+
         if(cache->commandBuffers.size){
             device->functions.vkFreeCommandBuffers(device->device, cache->commandPool, cache->commandBuffers.size, cache->commandBuffers.data);
             VkCommandBufferVector_free(&cache->commandBuffers);
@@ -952,7 +952,7 @@ static RenderPassLayout GetRenderPassLayout2(const RenderPassCommandBegin* rpdes
     if(rpdesc->depthAttachmentPresent){
         ret.depthAttachmentPresent = 1U;
         ret.depthAttachment = CLITERAL(AttachmentDescriptor){
-            .format = rpdesc->depthStencilAttachment.view->format, 
+            .format = rpdesc->depthStencilAttachment.view->format,
             .sampleCount = rpdesc->depthStencilAttachment.view->sampleCount,
             .loadop =  toVulkanLoadOperation(rpdesc->depthStencilAttachment.depthLoadOp),
             .storeop = toVulkanStoreOperation(rpdesc->depthStencilAttachment.depthStoreOp)
@@ -963,7 +963,7 @@ static RenderPassLayout GetRenderPassLayout2(const RenderPassCommandBegin* rpdes
     wgvk_assert(ret.colorAttachmentCount < MAX_COLOR_ATTACHMENTS, "Too many color attachments");
     for(uint32_t i = 0;i < rpdesc->colorAttachmentCount;i++){
         ret.colorAttachments[i] = CLITERAL(AttachmentDescriptor){
-            .format = rpdesc->colorAttachments[i].view->format, 
+            .format = rpdesc->colorAttachments[i].view->format,
             .sampleCount = rpdesc->colorAttachments[i].view->sampleCount,
             .loadop =  toVulkanLoadOperation (rpdesc->colorAttachments[i].loadOp),
             .storeop = toVulkanStoreOperation(rpdesc->colorAttachments[i].storeOp)
@@ -975,7 +975,7 @@ static RenderPassLayout GetRenderPassLayout2(const RenderPassCommandBegin* rpdes
         }
         if(rpdesc->colorAttachments[i].resolveTarget != 0){
             ret.colorResolveAttachments[i] = CLITERAL(AttachmentDescriptor){
-                .format = rpdesc->colorAttachments[i].resolveTarget->format, 
+                .format = rpdesc->colorAttachments[i].resolveTarget->format,
                 .sampleCount = rpdesc->colorAttachments[i].resolveTarget->sampleCount,
                 .loadop =  toVulkanLoadOperation (rpdesc->colorAttachments[i].loadOp),
                 .storeop = toVulkanStoreOperation(rpdesc->colorAttachments[i].storeOp)
@@ -988,23 +988,23 @@ static RenderPassLayout GetRenderPassLayout2(const RenderPassCommandBegin* rpdes
 RenderPassLayout GetRenderPassLayout(const WGPURenderPassDescriptor* rpdesc){
     RenderPassLayout ret zeroinit;
     //ret.colorResolveIndex = VK_ATTACHMENT_UNUSED;
-    
+
     if(rpdesc->depthStencilAttachment){
         wgvk_assert(rpdesc->depthStencilAttachment->view, "Depth stencil attachment passed but null view");
         ret.depthAttachmentPresent = 1U;
         ret.depthAttachment = CLITERAL(AttachmentDescriptor){
-            .format = rpdesc->depthStencilAttachment->view->format, 
+            .format = rpdesc->depthStencilAttachment->view->format,
             .sampleCount = rpdesc->depthStencilAttachment->view->sampleCount,
             .loadop =  toVulkanLoadOperation (rpdesc->depthStencilAttachment->depthLoadOp ),
             .storeop = toVulkanStoreOperation(rpdesc->depthStencilAttachment->depthStoreOp)
         };
     }
-    
+
     ret.colorAttachmentCount = rpdesc->colorAttachmentCount;
     wgvk_assert(ret.colorAttachmentCount < MAX_COLOR_ATTACHMENTS, "Too many color attachments");
     for(uint32_t i = 0;i < rpdesc->colorAttachmentCount;i++){
         ret.colorAttachments[i] = CLITERAL(AttachmentDescriptor){
-            .format = rpdesc->colorAttachments[i].view->format, 
+            .format = rpdesc->colorAttachments[i].view->format,
             .sampleCount = rpdesc->colorAttachments[i].view->sampleCount,
             .loadop =  toVulkanLoadOperation(rpdesc->colorAttachments[i].loadOp  ),
             .storeop = toVulkanStoreOperation(rpdesc->colorAttachments[i].storeOp)
@@ -1016,7 +1016,7 @@ RenderPassLayout GetRenderPassLayout(const WGPURenderPassDescriptor* rpdesc){
         }
         if(rpdesc->colorAttachments[i].resolveTarget != 0){
             ret.colorResolveAttachments[i] = CLITERAL(AttachmentDescriptor){
-                .format = rpdesc->colorAttachments[i].resolveTarget->format, 
+                .format = rpdesc->colorAttachments[i].resolveTarget->format,
                 .sampleCount = rpdesc->colorAttachments[i].resolveTarget->sampleCount,
                 .loadop =  toVulkanLoadOperation(rpdesc->colorAttachments[i].loadOp),
                 .storeop = toVulkanStoreOperation(rpdesc->colorAttachments[i].storeOp)
@@ -1070,7 +1070,7 @@ LayoutedRenderPass LoadRenderPassFromLayout(WGPUDevice device, RenderPassLayout 
         return *lrp;
 
     //TRACELOG(WGPU_LOG_INFO, "Loading new renderpass");
-    
+
     VkAttachmentDescriptionVector allAttachments;
     VkAttachmentDescriptionVector_init(&allAttachments);
     uint32_t depthAttachmentIndex = VK_ATTACHMENT_UNUSED; // index for depth attachment if any
@@ -1078,7 +1078,7 @@ LayoutedRenderPass LoadRenderPassFromLayout(WGPUDevice device, RenderPassLayout 
     for(uint32_t i = 0; i < layout.colorAttachmentCount;i++){
         VkAttachmentDescriptionVector_push_back(&allAttachments, atttransformFunction(layout.colorAttachments[i]));
     }
-    
+
     if(layout.depthAttachmentPresent){
         depthAttachmentIndex = allAttachments.size;
         VkAttachmentDescriptionVector_push_back(&allAttachments, atttransformFunction(layout.depthAttachment));
@@ -1091,9 +1091,9 @@ LayoutedRenderPass LoadRenderPassFromLayout(WGPUDevice device, RenderPassLayout 
         }
     }
 
-    
+
     const uint32_t colorAttachmentCount = layout.colorAttachmentCount;
-    
+
 
     // Set up color attachment references for the subpass.
     VkAttachmentReference colorRefs[MAX_COLOR_ATTACHMENTS] = {0}; // list of color attachments
@@ -1132,7 +1132,7 @@ LayoutedRenderPass LoadRenderPassFromLayout(WGPUDevice device, RenderPassLayout 
     } else {
         subpass.pResolveAttachments = NULL;
     }
-    
+
 
     VkRenderPassCreateInfo rpci = {
         VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
@@ -1142,7 +1142,7 @@ LayoutedRenderPass LoadRenderPassFromLayout(WGPUDevice device, RenderPassLayout 
         1, &subpass,
         0, NULL
     };
-    
+
     // (Optional: add subpass dependencies if needed.)
     LayoutedRenderPass ret zeroinit;
     VkAttachmentDescriptionVector_move(&ret.allAttachments, &allAttachments);
@@ -1185,7 +1185,7 @@ void wgpuTraceLog(int logType, const char *text, ...){
         case WGPU_LOG_FATAL:   strcpy(buffer, TERMCTL_RED "FATAL: "); break;
         default: break;
     }
-    
+
     unsigned int textSize = (unsigned int)strlen(text);
     memcpy(buffer + strlen(buffer), text, (textSize < (MAX_TRACELOG_MSG_LENGTH - 12))? textSize : (MAX_TRACELOG_MSG_LENGTH - 12));
     if(needs_reset){
@@ -1202,7 +1202,7 @@ void wgpuTraceLog(int logType, const char *text, ...){
     if (logType == WGPU_LOG_FATAL){
         fputs(TERMCTL_RED "Exiting due to fatal error!\n" TERMCTL_RESET, stderr);
         rg_trap();
-        exit(EXIT_FAILURE); 
+        exit(EXIT_FAILURE);
     }
 
     EXIT();
@@ -1253,13 +1253,13 @@ static inline bool isWritingAccess(VkAccessFlags flags){
 static inline int endswith_(const char* str, const char* suffix) {
     if (!str || !suffix)
         return 0;
-        
+
     size_t str_len = strlen(str);
     size_t suffix_len = strlen(suffix);
-    
+
     if (suffix_len > str_len)
         return 0;
-        
+
     return strcmp(str + str_len - suffix_len, suffix) == 0;
 }
 
@@ -1294,7 +1294,7 @@ WGPUInstance wgpuCreateInstance(const WGPUInstanceDescriptor* descriptor) {
 
     uint32_t availableExtensionCount = 0;
     VkResult enumResult = vkEnumerateInstanceExtensionProperties(NULL, &availableExtensionCount, NULL);
-    
+
     VkExtensionProperties* availableExtensions = NULL;
     const char** enabledExtensions = NULL; // Array of pointers to enabled names
     const uint32_t maxEnabledExtensions = 32;
@@ -1328,7 +1328,7 @@ WGPUInstance wgpuCreateInstance(const WGPUInstanceDescriptor* descriptor) {
     }
 
     int needsPortabilityEnumeration = 0;
-    #ifdef __APPLE__    
+    #ifdef __APPLE__
     needsPortabilityEnumeration = 1;
     #endif
     int portabilityEnumerationAvailable = 1;
@@ -1361,7 +1361,7 @@ WGPUInstance wgpuCreateInstance(const WGPUInstanceDescriptor* descriptor) {
     }
     // 2. Define Instance Create Info
 
-    
+
 
 
     // --- End Extension Handling ---
@@ -1384,7 +1384,7 @@ WGPUInstance wgpuCreateInstance(const WGPUInstanceDescriptor* descriptor) {
     char nullTerminatedRequestedLayers[64][64] = {0};
     const char* nullTerminatedRequestedLayerPointers[64] = {0};
     uint32_t requestedAvailableLayerCount = 0;
-    
+
     WGPUInstanceLayerSelection* ils = NULL;
     int debugUtilsAvailable = 0; // Check if debug utils was actually enabled
 
@@ -2028,7 +2028,7 @@ void wgpuCreateAdapter_sync(void* userdata_v){
                 break;
             }
         }
-        
+
         if(i >= physicalDeviceCount) {
             // No CPU device found - forceFallbackAdapter requires one
             RL_FREE((void*)pds);
@@ -2057,7 +2057,7 @@ void wgpuCreateAdapter_sync(void* userdata_v){
             preferenceOrder[1] = VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
             preferenceOrder[2] = VK_PHYSICAL_DEVICE_TYPE_CPU;
         }
-        
+
         // Try to find a GPU matching the preference
         for(uint32_t p = 0; p < 3 && i >= physicalDeviceCount; p++){
             for(uint32_t j = 0; j < physicalDeviceCount; j++){
@@ -2069,7 +2069,7 @@ void wgpuCreateAdapter_sync(void* userdata_v){
                 }
             }
         }
-        
+
         // If nothing matched, fail
         if(i >= physicalDeviceCount) {
             RL_FREE((void*)pds);
@@ -2129,7 +2129,7 @@ void wgpuCreateAdapter_sync(void* userdata_v){
     RL_FREE((void*)pds);
     RL_FREE((void*)props);
     adapter->deviceInfoCache = (VulkanDeviceInfo){0};
-    
+
     VulkanDeviceInfo* infoCache = &adapter->deviceInfoCache;
 
     infoCache->knobs.shaderFloat16Int8Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES;
@@ -2226,7 +2226,7 @@ static inline VkSemaphore CreateSemaphoreD(WGPUDevice device){
     VkSemaphoreCreateInfo sci = {
         VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO
     };
-    
+
     VkResult res = device->functions.vkCreateSemaphore(device->device, &sci, NULL, &ret);
     if(res != VK_SUCCESS){
         TRACELOG(WGPU_LOG_ERROR, "Error creating semaphore");
@@ -2261,7 +2261,7 @@ typedef struct userdataforcreatedevice{
 WGPUDevice wgpuAdapterCreateDevice(WGPUAdapter adapter, const WGPUDeviceDescriptor* descriptor){
     ENTRY();
     //std::pair<WGPUDevice, WGPUQueue> ret = {0,0};
-    
+
     int requiresYCbCr = 0;
     for(uint32_t i = 0;i < descriptor->requiredFeatureCount;i++){
         WGPUFeatureName feature = descriptor->requiredFeatures[i];
@@ -2271,7 +2271,7 @@ WGPUDevice wgpuAdapterCreateDevice(WGPUAdapter adapter, const WGPUDeviceDescript
                 requiresYCbCr = 1;
                 break;
             default:
-            (void)0; 
+            (void)0;
         }
     }
     // Collect unique queue families
@@ -2281,14 +2281,14 @@ WGPUDevice wgpuAdapterCreateDevice(WGPUAdapter adapter, const WGPUDeviceDescript
         adapter->queueIndices.presentIndex
     };
     uint32_t queueFamilyCount = sort_uniqueuints(queueFamilies, 3);
-    
+
     // Create queue create infos
     VkDeviceQueueCreateInfo queueCreateInfos[8] = {0};
     uint32_t queueCreateInfoCount = 0;
     float queuePriority = 1.0f;
 
     for (uint32_t queueFamilyIndex = 0;queueFamilyIndex < queueFamilyCount; queueFamilyIndex++) {
-        uint32_t queueFamily = queueFamilies[queueFamilyIndex]; 
+        uint32_t queueFamily = queueFamilies[queueFamilyIndex];
         if(queueFamily == VK_QUEUE_FAMILY_IGNORED)continue; // TODO handle this better
         VkDeviceQueueCreateInfo queueCreateInfo zeroinit;
         queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
@@ -2297,12 +2297,12 @@ WGPUDevice wgpuAdapterCreateDevice(WGPUAdapter adapter, const WGPUDeviceDescript
         queueCreateInfo.pQueuePriorities = &queuePriority;
         queueCreateInfos[queueCreateInfoCount++] = queueCreateInfo;
     }
-    
+
     uint32_t deviceExtensionCount = 0;
     vkEnumerateDeviceExtensionProperties(adapter->physicalDevice, NULL, &deviceExtensionCount, NULL);
     VkExtensionProperties* deprops = (VkExtensionProperties*)RL_CALLOC(deviceExtensionCount, sizeof(VkExtensionProperties));
     vkEnumerateDeviceExtensionProperties(adapter->physicalDevice, NULL, &deviceExtensionCount, deprops);
-    
+
     const char* deviceExtensionsToLookFor[] = {
         //#ifndef FORCE_HEADLESS
         VK_KHR_SWAPCHAIN_EXTENSION_NAME,
@@ -2324,7 +2324,7 @@ WGPUDevice wgpuAdapterCreateDevice(WGPUAdapter adapter, const WGPUDeviceDescript
         VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME,    // For NV12/P010 textures
     };
     #define deviceExtensionsToLookForCount (sizeof(deviceExtensionsToLookFor) / sizeof(const char*))
-    
+
     int depthClipControl_Found = 0;
     int depthClipEnable_Found = 0;
 
@@ -2350,7 +2350,7 @@ WGPUDevice wgpuAdapterCreateDevice(WGPUAdapter adapter, const WGPUDeviceDescript
         if(deviceExtensionFound == 0){
             printf("Device extension not found: %s\n", deviceExtensionsToLookFor[i]);
         }
-        
+
     }
 
     VkPhysicalDeviceBufferDeviceAddressFeaturesKHR deviceFeaturesAddressKhr = {
@@ -2374,7 +2374,7 @@ WGPUDevice wgpuAdapterCreateDevice(WGPUAdapter adapter, const WGPUDeviceDescript
         .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES,
         .pNext = &accelerationStructureFeatures,
     };
-    
+
     VkPhysicalDeviceFeatures2 deviceFeatures = {
         .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2,
     };
@@ -2412,7 +2412,7 @@ WGPUDevice wgpuAdapterCreateDevice(WGPUAdapter adapter, const WGPUDeviceDescript
         .enabledExtensionCount = extInsertIndex,
         .ppEnabledExtensionNames = deviceExtensionsFound,
     };
-    
+
     WGPUDevice retDevice = RL_CALLOC(1, sizeof(WGPUDeviceImpl));
 
     retDevice->refCount = 1;
@@ -2425,8 +2425,8 @@ WGPUDevice wgpuAdapterCreateDevice(WGPUAdapter adapter, const WGPUDeviceDescript
     } else {
         //TRACELOG(WGPU_LOG_INFO, "Successfully created logical device");
         volkLoadDeviceTable(&retDevice->functions, retDevice->device);
-        retDevice->capabilities.depthClipEnable = depthClipEnable_Found;    
-        retDevice->capabilities.depthClipControl = depthClipControl_Found;    
+        retDevice->capabilities.depthClipEnable = depthClipEnable_Found;
+        retDevice->capabilities.depthClipControl = depthClipControl_Found;
     }
     retDevice->capabilities.dynamicRendering = v13features.dynamicRendering;
     retDevice->capabilities.raytracing = pipelineFeatures.rayTracingPipeline && accelerationStructureFeatures.accelerationStructure;
@@ -2453,19 +2453,19 @@ WGPUDevice wgpuAdapterCreateDevice(WGPUAdapter adapter, const WGPUDeviceDescript
             }
             chain = chain->next;
         }
-        
+
         // Check all limits and collect errors
         int hasError = 0;
         const WGPULimits* required = descriptor->requiredLimits;
         const WGPULimits* supported = &adapterLimits;
-        
+
         #define CHECK_MAX_LIMIT(field) \
             if (required->field > supported->field) { \
                 TRACELOG(WGPU_LOG_ERROR, "Required limit " #field " (%llu) exceeds adapter capabilities (%llu)", \
                          (unsigned long long)required->field, (unsigned long long)supported->field); \
                 hasError = 1; \
             }
-        
+
         CHECK_MAX_LIMIT(maxTextureDimension1D);
         CHECK_MAX_LIMIT(maxTextureDimension2D);
         CHECK_MAX_LIMIT(maxTextureDimension3D);
@@ -2495,12 +2495,12 @@ WGPUDevice wgpuAdapterCreateDevice(WGPUAdapter adapter, const WGPUDeviceDescript
         CHECK_MAX_LIMIT(maxComputeWorkgroupSizeY);
         CHECK_MAX_LIMIT(maxComputeWorkgroupSizeZ);
         CHECK_MAX_LIMIT(maxComputeWorkgroupsPerDimension);
-        
+
         #undef CHECK_MAX_LIMIT
-        
+
         // Check alignment limits (lower is better, must be >= supported and power of 2)
         #define IS_POWER_OF_2(x) ((x) != 0 && ((x) & ((x) - 1)) == 0)
-        
+
         #define CHECK_ALIGNMENT_LIMIT(field) \
             if (!IS_POWER_OF_2(required->field)) { \
                 TRACELOG(WGPU_LOG_ERROR, "Required limit " #field " (%u) must be a power of 2", \
@@ -2511,13 +2511,13 @@ WGPUDevice wgpuAdapterCreateDevice(WGPUAdapter adapter, const WGPUDeviceDescript
                          required->field, supported->field); \
                 hasError = 1; \
             }
-        
+
         CHECK_ALIGNMENT_LIMIT(minUniformBufferOffsetAlignment);
         CHECK_ALIGNMENT_LIMIT(minStorageBufferOffsetAlignment);
-        
+
         #undef CHECK_ALIGNMENT_LIMIT
         #undef IS_POWER_OF_2
-        
+
         // Check extras limits if both are present
         if (reqExtras) {
             #define CHECK_EXTRAS_LIMIT(field) \
@@ -2526,15 +2526,15 @@ WGPUDevice wgpuAdapterCreateDevice(WGPUAdapter adapter, const WGPUDeviceDescript
                              reqExtras->field, adapterExtrasLimits.field); \
                     hasError = 1; \
                 }
-            
+
             CHECK_EXTRAS_LIMIT(maxStorageBuffersInVertexStage);
             CHECK_EXTRAS_LIMIT(maxStorageTexturesInVertexStage);
             CHECK_EXTRAS_LIMIT(maxStorageBuffersInFragmentStage);
             CHECK_EXTRAS_LIMIT(maxStorageTexturesInFragmentStage);
-            
+
             #undef CHECK_EXTRAS_LIMIT
         }
-        
+
         if(hasError){
             // Clean up and return NULL
             retDevice->functions.vkDestroyDevice(retDevice->device, NULL);
@@ -2543,7 +2543,7 @@ WGPUDevice wgpuAdapterCreateDevice(WGPUAdapter adapter, const WGPUDeviceDescript
             RL_FREE(deprops);
             return NULL;
         }
-        
+
         // Limits validated, now set them on the device
         retDevice->limits = *descriptor->requiredLimits;
         retDevice->limits.nextInChain = NULL;
@@ -2560,7 +2560,7 @@ WGPUDevice wgpuAdapterCreateDevice(WGPUAdapter adapter, const WGPUDeviceDescript
     retDevice->extrasLimits.chain.next = NULL;
 
     // Retrieve and assign queues
-    
+
     QueueIndices indices = adapter->queueIndices;
     retDevice->uncapturedErrorCallbackInfo = descriptor->uncapturedErrorCallbackInfo;
     retDevice->functions.vkGetDeviceQueue(retDevice->device, indices.graphicsIndex, 0, &retQueue->graphicsQueue);
@@ -2584,12 +2584,12 @@ WGPUDevice wgpuAdapterCreateDevice(WGPUAdapter adapter, const WGPUDeviceDescript
         .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT
     };
     retDevice->functions.vkCreateCommandPool(retDevice->device, &pci, NULL, &retDevice->secondaryCommandPool);
-    
+
     WGPUCommandEncoderDescriptor cedesc = {0};
 
     FenceCache_Init(retDevice, &retDevice->fenceCache);
     FIFCache_init(&retDevice->fifCache, retDevice, adapter->queueIndices.graphicsIndex);
-    
+
     retQueue->presubmitCache = wgpuDeviceCreateCommandEncoder(retDevice, &cedesc);
     VkDeviceSize limit = (((uint64_t)1) << 30);
 
@@ -2597,7 +2597,7 @@ WGPUDevice wgpuAdapterCreateDevice(WGPUAdapter adapter, const WGPUDeviceDescript
     vkGetPhysicalDeviceMemoryProperties2(adapter->physicalDevice, &memoryProperties);
 
     VkDeviceSize heapsizes[128] = {0};
-    
+
     for(uint32_t i = 0;i < memoryProperties.memoryProperties.memoryHeapCount;i++){
         heapsizes[i] = limit;
     }
@@ -2607,9 +2607,9 @@ WGPUDevice wgpuAdapterCreateDevice(WGPUAdapter adapter, const WGPUDeviceDescript
             break;
         }
     }
-    
+
     #if USE_VMA_ALLOCATOR == 1
-    
+
     const VmaPoolCreateInfo vpci = {
         .minAllocationAlignment = 64,
         .memoryTypeIndex = hostVisibleCoherentIndex,
@@ -2634,7 +2634,7 @@ WGPUDevice wgpuAdapterCreateDevice(WGPUAdapter adapter, const WGPUDeviceDescript
     if(allocatorCreateResult != VK_SUCCESS){
         DeviceCallback(retDevice, WGPUErrorType_Internal, STRVIEW("Failed to create allocator"));
     }
-    
+
     vmaCreatePool(retDevice->allocator, &vpci, &retDevice->aligned_hostVisiblePool);
     #endif
     retDevice->thread_pool = wgvk_thread_pool_create(4);
@@ -2713,7 +2713,7 @@ void wgpuBufferMapSync(void* data){
     userdataformapbufferasync* info = (userdataformapbufferasync*)data;
     void* mapdata = NULL;
     wgpuBufferMap(info->buffer, info->mode, info->offset, info->size, &mapdata);
-    
+
     info->info.callback(WGPUMapAsyncStatus_Success, (WGPUStringView){"", 0}, info->info.userdata1, info->info.userdata2);
     EXIT();
 }
@@ -2722,7 +2722,7 @@ void wgpuBufferMap(WGPUBuffer buffer, WGPUMapMode mapmode, size_t offset, size_t
 WGPUBuffer wgpuDeviceCreateBuffer(WGPUDevice device, const WGPUBufferDescriptor* desc){
     ENTRY();
     //vmaCreateAllocator(const VmaAllocatorCreateInfo * _Nonnull pCreateInfo, VmaAllocator  _Nullable * _Nonnull pAllocator)
-    
+
     if(desc->usage & WGPUBufferUsage_MapRead){
         if(desc->usage & ~(WGPUBufferUsage_CopyDst | WGPUBufferUsage_MapRead)){
             DeviceCallback(device, WGPUErrorType_Validation, STRVIEW("WGPUBufferUsage_MapRead used with something other than WGPUBufferUsage_CopyDst"));
@@ -2741,15 +2741,15 @@ WGPUBuffer wgpuDeviceCreateBuffer(WGPUDevice device, const WGPUBufferDescriptor*
     wgpuBuffer->cacheIndex = cacheIndex;
     wgpuBuffer->refCount = 1;
     wgpuBuffer->usage = desc->usage;
-    
-    
+
+
     const VkBufferCreateInfo bufferDesc = {
         .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
         .size = desc->size,
         .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
         .usage = toVulkanBufferUsage(desc->usage),
     };
-    
+
     VkMemoryPropertyFlags propertyToFind = 0;
     if(desc->usage & (WGPUBufferUsage_MapRead | WGPUBufferUsage_MapWrite)){
         propertyToFind = VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
@@ -2852,7 +2852,7 @@ void wgpuBufferMap(WGPUBuffer buffer, WGPUMapMode mapmode, size_t offset, size_t
         rg_unreachable();
         *data = NULL;
     }
-    
+
     EXIT();
 }
 
@@ -2922,7 +2922,7 @@ uint64_t wgpuBufferGetSize(WGPUBuffer buffer){
         }break;
         default:
         rg_unreachable();
-        
+
     }
     EXIT();
 }
@@ -2932,12 +2932,12 @@ void wgpuQueueWriteBuffer(WGPUQueue cSelf, WGPUBuffer buffer, uint64_t bufferOff
     if(buffer->memoryProperties & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT){
         void* mappedMemory = NULL;
         wgpuBufferMap(buffer, WGPUMapMode_Write, bufferOffset, size, &mappedMemory);
-        
+
         if (mappedMemory != NULL) {
             // Memory is host mappable: copy data and unmap.
             memcpy(mappedMemory, data, size);
             wgpuBufferUnmap(buffer);
-            
+
         }
     }
     else{
@@ -2982,7 +2982,7 @@ WGPUFence wgpuDeviceCreateFence(WGPUDevice device){
     fence->refCount = 1;
     fence->device = device;
     CallbackWithUserdataVector_init(&fence->callbacksOnWaitComplete);
-    
+
     // Initialize the new synchronization primitives
     fence->wait_mutex = wgvk_mutex_create(wgvk_locktype_kernel);
     fence->wait_cond = wgvk_cond_create(wgvk_locktype_kernel);
@@ -2999,7 +2999,7 @@ WGPUFence wgpuDeviceCreateFence(WGPUDevice device){
     }
 
     fence->fence = FenceCache_GetFence(&device->fenceCache);
-    
+
     // The fence starts in a "reset" state, ready to be used.
     atomic_init(&fence->state, WGPUFenceState_Reset);
     return fence;
@@ -3030,7 +3030,7 @@ void wgpuFenceWait(WGPUFence fence, uint64_t timeoutNS) {
     }
 
     bool is_designated_waiter = false;
-    
+
     // Attempt to become the designated waiter. This is an atomic operation.
     WGPUFenceState expected_state = WGPUFenceState_InUse;
     if (atomic_compare_exchange_strong_explicit(&fence->state, &expected_state, WGPUFenceState_Waiting, memory_order_acq_rel, memory_order_acquire)) {
@@ -3040,7 +3040,7 @@ void wgpuFenceWait(WGPUFence fence, uint64_t timeoutNS) {
     if (is_designated_waiter) {
         VkResult waitResult = fence->device->functions.vkWaitForFences(
             fence->device->device, 1, &fence->fence, VK_TRUE, timeoutNS);
-        
+
         wgvk_assert(waitResult == VK_SUCCESS || waitResult == VK_TIMEOUT, "vkWaitForFences returned an unexpected error.");
 
         // Lock the mutex to safely update state and signal followers.
@@ -3156,7 +3156,7 @@ WGPUTexture wgpuDeviceCreateTexture(WGPUDevice device, const WGPUTextureDescript
     if(descriptor->dimension == WGPUTextureDimension_2D && descriptor->size.depthOrArrayLayers >= 6){
         imageInfo.flags |= VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
     }
-    
+
     VkImage image zeroinit;
     if (device->functions.vkCreateImage(device->device, &imageInfo, NULL, &image) != VK_SUCCESS){
         TRACELOG(WGPU_LOG_ERROR, "Failed to create image!");
@@ -3256,9 +3256,9 @@ static inline VkDescriptorType contiguousDescriptorType(uint32_t cont){
 
 void wgpuWriteBindGroup(WGPUDevice device, WGPUBindGroup wvBindGroup, const WGPUBindGroupDescriptor* bgdesc){
     ENTRY();
-    
+
     wgvk_assert(bgdesc->layout != NULL, "WGPUBindGroupDescriptor::layout is null");
-    
+
     if(wvBindGroup->pool == NULL){
         wvBindGroup->layout = bgdesc->layout;
 
@@ -3275,7 +3275,7 @@ void wgpuWriteBindGroup(WGPUDevice device, WGPUBindGroup wvBindGroup, const WGPU
         for(uint32_t i = 0;i < DESCRIPTOR_TYPE_UPPER_LIMIT;i++){
             if(counts[i] != 0){
                 sizes[VkDescriptorPoolSizeCount++] = (VkDescriptorPoolSize){
-                    .type = contiguousDescriptorType(i), 
+                    .type = contiguousDescriptorType(i),
                     .descriptorCount = counts[i]
                 };
             }
@@ -3324,9 +3324,9 @@ void wgpuWriteBindGroup(WGPUDevice device, WGPUBindGroup wvBindGroup, const WGPU
     releaseAllAndClear(&wvBindGroup->resourceUsage);
     ResourceUsage_move(&wvBindGroup->resourceUsage, &newResourceUsage);
 
-    
+
     uint32_t count = bgdesc->entryCount;
-     
+
     VkWriteDescriptorSetVector writes zeroinit;
     VkDescriptorBufferInfoVector bufferInfos zeroinit;
     VkDescriptorImageInfoVector imageInfos zeroinit;
@@ -3415,7 +3415,7 @@ void wgpuWriteBindGroup(WGPUDevice device, WGPUBindGroup wvBindGroup, const WGPU
 WGPUBindGroup wgpuDeviceCreateBindGroup(WGPUDevice device, const WGPUBindGroupDescriptor* bgdesc){
     ENTRY();
     wgvk_assert(bgdesc->layout != NULL, "WGPUBindGroupDescriptor::layout is null");
-    
+
     WGPUBindGroup ret = RL_CALLOC(1, sizeof(WGPUBindGroupImpl));
     ret->refCount = 1;
     ResourceUsage_init(&ret->resourceUsage);
@@ -3445,7 +3445,7 @@ WGPUBindGroup wgpuDeviceCreateBindGroup(WGPUDevice device, const WGPUBindGroupDe
         for(uint32_t i = 0;i < DESCRIPTOR_TYPE_UPPER_LIMIT;i++){
             if(counts[i] != 0){
                 sizes[VkDescriptorPoolSizeCount++] = (VkDescriptorPoolSize){
-                    .type = contiguousDescriptorType(i), 
+                    .type = contiguousDescriptorType(i),
                     .descriptorCount = counts[i]
                 };
             }
@@ -3492,7 +3492,7 @@ WGPUBindGroupLayout wgpuDeviceCreateBindGroupLayout(WGPUDevice device, const WGP
     ret->refCount = 1;
     ret->device = device;
     ret->entryCount = bgldesc->entryCount;
-    
+
     const WGPUBindGroupLayoutEntry* entries = bgldesc->entries;
     const uint32_t entryCount = bgldesc->entryCount;
 
@@ -3514,7 +3514,7 @@ WGPUBindGroupLayout wgpuDeviceCreateBindGroupLayout(WGPUDevice device, const WGP
             vkBindings.data[i].stageFlags = toVulkanShaderStageBits(entries[i].visibility);
         }
     }
-    
+
     VkDescriptorSetLayoutCreateInfo slci = {
         .bindingCount = bgldesc->entryCount,
         .pBindings = vkBindings.data,
@@ -3534,7 +3534,7 @@ WGPUBindGroupLayout wgpuDeviceCreateBindGroupLayout(WGPUDevice device, const WGP
     ret->entries = entriesCopy;
 
     VkDescriptorSetLayoutBindingVector_free(&vkBindings);
-    
+
     EXIT();
     return ret;
 }
@@ -3604,7 +3604,7 @@ WGPUShaderModule wgpuDeviceCreateShaderModule(WGPUDevice device, const WGPUShade
         case WGPUSType_ShaderSourceWGSL: {
             const WGPUShaderSourceWGSL* source = (WGPUShaderSourceWGSL*)descriptor->nextInChain;
             size_t length = (source->code.length == WGPU_STRLEN) ? strlen(source->code.data) : source->code.length;
-            
+
             tc_SpirvBlob blob = wgslToSpirv(source, 0, NULL);
 
             // Extract specialization constant mapping from the first valid SPIR-V blob
@@ -3657,7 +3657,7 @@ WGPUShaderModule wgpuDeviceCreateShaderModule(WGPUDevice device, const WGPUShade
             };
 
             memcpy((void*)depot->code.data, source->code.data, length);
-            
+
             ret->source = (WGPUChainedStruct*)depot;
             return ret;
         }
@@ -3750,9 +3750,9 @@ WGPUCommandEncoder wgpuDeviceCreateCommandEncoder(WGPUDevice device, const WGPUC
         .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
         .pInheritanceInfo = NULL
     };
-    
+
     device->functions.vkBeginCommandBuffer(ret->buffer, &bbi);
-    
+
     return ret;
     EXIT();
 }
@@ -3835,7 +3835,7 @@ WGPUTextureView wgpuTextureCreateView(WGPUTexture texture, const WGPUTextureView
         .viewType = ivci.viewType
     };
     WGPUTextureView* hit_pointer = Texture_ViewCache_get(&texture->viewCache, key);
-    
+
     if(hit_pointer){
         WGPUTextureView hit = *hit_pointer;
         if(hit->refCount == 0){
@@ -3844,7 +3844,7 @@ WGPUTextureView wgpuTextureCreateView(WGPUTexture texture, const WGPUTextureView
         wgpuTextureViewAddRef(hit);
         return hit;
     }
-    
+
     //if(!is__depthVk(ivci.format)){
     //    sr.aspectMask &= VK_IMAGE_ASPECT_COLOR_BIT;
     //}
@@ -3859,7 +3859,7 @@ WGPUTextureView wgpuTextureCreateView(WGPUTexture texture, const WGPUTextureView
     ret->sampleCount = texture->sampleCount;
     ret->depthOrArrayLayers = texture->depthOrArrayLayers;
     ret->subresourceRange = ivci.subresourceRange;
-    
+
     Texture_ViewCache_put(&texture->viewCache, key, ret);
     return ret;
     EXIT();
@@ -3947,10 +3947,10 @@ WGPURenderBundleEncoder wgpuDeviceCreateRenderBundleEncoder(WGPUDevice device, c
     //}
 
 
-    
+
     //device->functions.vkCmdSetViewport(ret->buffer, 0, 1, &viewPort);
     //device->functions.vkCmdSetScissor (ret->buffer, 0, 1, &scissor);
-    
+
     //VkViewport dummy_viewport = { 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f };
     //VkRect2D dummy_scissor = { {0, 0}, {1, 1} };
     //vkCmdSetViewport(ret->buffer, 0, 1, &dummy_viewport);
@@ -4051,7 +4051,7 @@ void wgpuRenderBundleEncoderSetBindGroup(WGPURenderBundleEncoder renderBundleEnc
 
 void wgpuRenderBundleEncoderSetIndexBuffer(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer buffer, WGPUIndexFormat format, uint64_t offset, uint64_t size) WGPU_FUNCTION_ATTRIBUTE{
     ENTRY();
-    
+
     RenderPassCommandGeneric cmd = {
         .type = rp_command_type_set_index_buffer,
         .setIndexBuffer = {
@@ -4127,11 +4127,11 @@ WGPURenderPassEncoder wgpuCommandEncoderBeginRenderPass(WGPUCommandEncoder enc, 
     (void)pool;
     ++enc->encodedCommandCount;
     ret->refCount = 2; //One for WGPURenderPassEncoder the other for the command buffer
-    
+
     WGPURenderPassEncoderSet_add(&enc->referencedRPs, ret);
     //enc->referencedRPs.insert(ret);
     ret->device = enc->device;
-    
+
     ret->cmdEncoder = enc;
     #if VULKAN_USE_DYNAMIC_RENDERING == 1
     //vkCmdBeginRendering(ret->cmdBuffer, &info);
@@ -4144,7 +4144,7 @@ WGPURenderPassEncoder wgpuCommandEncoderBeginRenderPass(WGPUCommandEncoder enc, 
 
     VkImageView attachmentViews[2 * max_color_attachments + 2] = {0};// = (VkImageView* )RL_CALLOC(frp.allAttachments.size, sizeof(VkImageView) );
     VkClearValue clearValues   [2 * max_color_attachments + 2] = {0};// = (VkClearValue*)RL_CALLOC(frp.allAttachments.size, sizeof(VkClearValue));
-    
+
     for(uint32_t i = 0;i < rplayout.colorAttachmentCount;i++){
         attachmentViews[i] = rpdesc->colorAttachments[i].view->view;
         clearValues[i] = toVkCV(rpdesc->colorAttachments[i].clearValue);
@@ -4156,7 +4156,7 @@ WGPURenderPassEncoder wgpuCommandEncoderBeginRenderPass(WGPUCommandEncoder enc, 
         clearValues[insertIndex].depthStencil.stencil = rpdesc->depthStencilAttachment->stencilClearValue;
         attachmentViews[insertIndex++] = rpdesc->depthStencilAttachment->view->view;
     }
-    
+
     if(rpdesc->colorAttachments[0].resolveTarget){
         for(uint32_t i = 0;i < rplayout.colorAttachmentCount;i++){
             wgvk_assert(rpdesc->colorAttachments[i].resolveTarget, "All must have resolve or none");
@@ -4183,13 +4183,13 @@ WGPURenderPassEncoder wgpuCommandEncoderBeginRenderPass(WGPUCommandEncoder enc, 
     fbci.width = rpdesc->colorAttachments[0].view->width;
     fbci.height = rpdesc->colorAttachments[0].view->height;
     fbci.layers = 1;
-    
+
     fbci.renderPass = ret->renderPass;
     //VkResult fbresult = vkCreateFramebuffer(enc->device->device, &fbci, NULL, &ret->frameBuffer);
     //if(fbresult != VK_SUCCESS){
     //    TRACELOG(WGPU_LOG_FATAL, "Error creating framebuffer: %d", (int)fbresult);
     //}
-    
+
     rpbi.renderPass = ret->renderPass;
     rpbi.renderArea = CLITERAL(VkRect2D){
         .offset = CLITERAL(VkOffset2D){0, 0},
@@ -4197,13 +4197,13 @@ WGPURenderPassEncoder wgpuCommandEncoderBeginRenderPass(WGPUCommandEncoder enc, 
     };
 
     rpbi.framebuffer = ret->frameBuffer;
-    
-    
+
+
     rpbi.clearValueCount = frp.allAttachments.size;
     rpbi.pClearValues = clearValues;
-    
+
     ret->cmdEncoder = enc;
-    
+
     //vkCmdBeginRenderPass(ret->secondaryCmdBuffer, &rpbi, VK_SUBPASS_CONTENTS_INLINE);
     #endif
     ret->beginInfo = CLITERAL(RenderPassCommandBegin){
@@ -4240,7 +4240,7 @@ WGPURenderPassEncoder wgpuCommandEncoderBeginRenderPass(WGPUCommandEncoder enc, 
     };
 
     const ImageUsageSnap iur_resolve = iur_color;
-    
+
     const ImageUsageSnap iur_depth = {
         .layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
         .access = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT,
@@ -4254,7 +4254,7 @@ WGPURenderPassEncoder wgpuCommandEncoderBeginRenderPass(WGPUCommandEncoder enc, 
         }
     };
 
-    
+
     for(uint32_t i = 0;i < rpdesc->colorAttachmentCount;i++){
         wgvk_assert(rpdesc->colorAttachments[i].view, "colorAttachments[%d].view is null", (int)i);
         ce_trackTextureView(enc, rpdesc->colorAttachments[i].view, iur_color);
@@ -4277,7 +4277,7 @@ WGPURenderPassEncoder wgpuCommandEncoderBeginRenderPass(WGPUCommandEncoder enc, 
 
 void wgpuRenderPassEncoderEnd(WGPURenderPassEncoder renderPassEncoder){
     ENTRY();
-    
+
     WGPUDevice device = renderPassEncoder->device;
     VkCommandBuffer destination = renderPassEncoder->cmdEncoder->buffer;
     const RenderPassCommandBegin* beginInfo = &renderPassEncoder->beginInfo;
@@ -4286,7 +4286,7 @@ void wgpuRenderPassEncoderEnd(WGPURenderPassEncoder renderPassEncoder){
     VkRect2D renderPassRect = {
         .offset = {0, 0},
         .extent = {
-            beginInfo->colorAttachments[0].view->width, 
+            beginInfo->colorAttachments[0].view->width,
             beginInfo->colorAttachments[0].view->height
         }
     };
@@ -4300,7 +4300,7 @@ void wgpuRenderPassEncoderEnd(WGPURenderPassEncoder renderPassEncoder){
             for(uint32_t bindingIndex = 0;bindingIndex < layout->entryCount;bindingIndex++){
 
                 wgvk_assert(group->entries[bindingIndex].binding == layout->entries[bindingIndex].binding, "Mismatch between layout and group, this will cause bugs.");
-                
+
                 const WGPUBindGroupEntry*       groupEntry  = &group ->entries[bindingIndex];
                 const WGPUBindGroupLayoutEntry* layoutEntry = &layout->entries[bindingIndex];
 
@@ -4364,13 +4364,13 @@ void wgpuRenderPassEncoderEnd(WGPURenderPassEncoder renderPassEncoder){
         clearValues[i]     = toVkCV(renderPassEncoder->beginInfo.colorAttachments[i].clearValue);
     }
     uint32_t insertIndex = rplayout.colorAttachmentCount;
-    
+
     if(beginInfo->depthAttachmentPresent){
         clearValues[insertIndex].depthStencil.depth   = beginInfo->depthStencilAttachment.depthClearValue;
         clearValues[insertIndex].depthStencil.stencil = beginInfo->depthStencilAttachment.stencilClearValue;
         attachmentViews[insertIndex++]                = beginInfo->depthStencilAttachment.view->view;
     }
-    
+
     if(beginInfo->colorAttachments[0].resolveTarget){
         for(uint32_t i = 0;i < rplayout.colorAttachmentCount;i++){
             wgvk_assert(beginInfo->colorAttachments[i].resolveTarget, "All must have resolve or none");
@@ -4452,7 +4452,7 @@ void wgpuRenderPassEncoderEnd(WGPURenderPassEncoder renderPassEncoder){
     const uint32_t vpWidth_u32  = beginInfo->colorAttachments[0].view->width;
     const float vpHeight        = (float)beginInfo->colorAttachments[0].view->height;
     const uint32_t vpHeight_u32 = beginInfo->colorAttachments[0].view->height;
-    
+
     const VkViewport viewport = {
         .x        = 0,
         .y        = vpHeight,
@@ -4506,13 +4506,13 @@ void wgpuRenderPassEncoderEnd(WGPURenderPassEncoder renderPassEncoder){
  * @brief Ends a CommandEncoder into a CommandBuffer
  * @details This is a one-way transition for WebGPU, therefore we can move resource tracking
  * In Vulkan, this transition is merely a call to vkEndCommandBuffer.
- * 
- * The rest of this function just moves data from the Encoder struct into the buffer. 
- * 
+ *
+ * The rest of this function just moves data from the Encoder struct into the buffer.
+ *
  */
 WGPUCommandBuffer wgpuCommandEncoderFinish(WGPUCommandEncoder commandEncoder, const WGPUCommandBufferDescriptor* bufferdesc){
     ENTRY();
-    
+
     WGPUCommandBuffer ret = RL_CALLOC(1, sizeof(WGPUCommandBufferImpl));
     ret->refCount = 1;
     wgvk_assert(commandEncoder->movedFrom == 0, "Command encoder is already invalidated");
@@ -4527,7 +4527,7 @@ WGPUCommandBuffer wgpuCommandEncoderFinish(WGPUCommandEncoder commandEncoder, co
     ret->buffer = commandEncoder->buffer;
     ret->device = commandEncoder->device;
     commandEncoder->buffer = NULL;
-    
+
     if(bufferdesc){
         ret->label = WGPUStringFromView(bufferdesc->label);
     }
@@ -4553,7 +4553,7 @@ void recordVkCommand(CommandBufferAndSomeState* destination_, const RenderPassCo
         break;
 
         case rp_command_type_draw_indirect:{
-            
+
             const RenderPassCommandDrawIndirect* drawIndirect = &command->drawIndirect;
             device->functions.vkCmdDrawIndirect(
                 destinationVk,
@@ -4620,7 +4620,7 @@ void recordVkCommand(CommandBufferAndSomeState* destination_, const RenderPassCo
         case rp_command_type_draw: {
             const RenderPassCommandDraw* draw = &command->draw;
             device->functions.vkCmdDraw(
-                destinationVk, 
+                destinationVk,
                 draw->vertexCount,
                 draw->instanceCount,
                 draw->firstVertex,
@@ -4704,14 +4704,14 @@ void recordVkCommand(CommandBufferAndSomeState* destination_, const RenderPassCo
         break;
         case rt_command_type_trace_rays: {
             const RaytracingPassCommandTraceRays* traceRays = &command->traceRays;
-                
+
             WGPURaytracingPipeline pipeline = destination_->lastRaytracingPipeline;
             wgvk_assert(pipeline != NULL, "vkCmdTraceRaysKHR called without a bound ray tracing pipeline.");
-                
+
             WGPUBuffer sbtBuffer = pipeline->sbtBuffer;
             VkDeviceSize totalSbtSize = pipeline->totalSbtSize;
             wgvk_assert(sbtBuffer != NULL, "Ray tracing pipeline does not have a valid SBT buffer.");
-                
+
             // Get properties to calculate the stride between handles.
             const VkPhysicalDeviceRayTracingPipelinePropertiesKHR* rtProperties = &device->adapter->rayTracingPipelineProperties;
             const uint32_t handleSize = rtProperties->shaderGroupHandleSize;
@@ -4719,14 +4719,14 @@ void recordVkCommand(CommandBufferAndSomeState* destination_, const RenderPassCo
 
             // handleStride is usually 32
             const VkDeviceSize handleStride = (handleSize + (handleAlignment - 1)) & ~(handleAlignment - 1);
-                
+
             const VkDeviceAddress sbtBaseAddress = sbtBuffer->address;
 
             char groupDump_[32 * 3] = {0};
             void* groupDump = groupDump_;
             device->functions.vkGetRayTracingShaderGroupHandlesKHR(device->device, pipeline->raytracingPipeline, 0, 3, (size_t)32 * 3, groupDump);
 
-            VkDeviceSize rayGenRegionSize = traceRays->rayMissOffset - traceRays->rayGenerationOffset;    
+            VkDeviceSize rayGenRegionSize = traceRays->rayMissOffset - traceRays->rayGenerationOffset;
             VkDeviceSize missRegionSize = traceRays->rayHitOffset - traceRays->rayMissOffset;
             VkDeviceSize hitRegionSize = totalSbtSize - traceRays->rayHitOffset;
             (void)rayGenRegionSize;
@@ -4734,27 +4734,27 @@ void recordVkCommand(CommandBufferAndSomeState* destination_, const RenderPassCo
             (void)hitRegionSize;
 
 
-                
+
             const VkStridedDeviceAddressRegionKHR raygenSbtRegion = {
                 .deviceAddress = sbtBaseAddress + traceRays->rayGenerationOffset * handleStride,
                 .stride        = handleStride,
                 .size          = handleStride
             };
-        
+
             const VkStridedDeviceAddressRegionKHR missSbtRegion = {
                 .deviceAddress = sbtBaseAddress + traceRays->rayMissOffset * handleStride,
                 .stride        = handleStride,
                 .size          = handleStride
             };
-        
+
             const VkStridedDeviceAddressRegionKHR hitSbtRegion = {
                 .deviceAddress = sbtBaseAddress + traceRays->rayHitOffset * handleStride,
                 .stride        = handleStride,
                 .size          = handleStride
             };
-            
+
             const VkStridedDeviceAddressRegionKHR callableSbtRegion = { .deviceAddress = 0, .stride = 0, .size = 0 };
-        
+
             device->functions.vkCmdTraceRaysKHR(
                 destinationVk,
                 &raygenSbtRegion,
@@ -4787,7 +4787,7 @@ void recordVkCommand(CommandBufferAndSomeState* destination_, const RenderPassCo
                     .commandBufferCount = 1
                 };
                 device->functions.vkAllocateCommandBuffers(device->device, &bai, &executedBuffer);
-                
+
                 VkCommandBufferInheritanceRenderingInfo renderingInfo = {
                     .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_RENDERING_INFO,
                     .colorAttachmentCount = bundle->colorAttachmentCount,
@@ -4796,12 +4796,12 @@ void recordVkCommand(CommandBufferAndSomeState* destination_, const RenderPassCo
                     .stencilAttachmentFormat = bundle->depthStencilFormat,
                     .rasterizationSamples = 1 // todo
                 };
-            
+
                 VkCommandBufferInheritanceInfo inheritanceInfo = {
                     .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO,
                     .pNext = &renderingInfo,
                 };
-            
+
                 VkCommandBufferBeginInfo beginInfo = {
                     .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
                     .flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT | VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT,
@@ -4811,7 +4811,7 @@ void recordVkCommand(CommandBufferAndSomeState* destination_, const RenderPassCo
                 RenderPassCommandBegin dummyBeginInfo = {
                     .colorAttachmentCount = bundle->colorAttachmentCount
                 };
-                
+
                 for(uint32_t ai = 0;ai < bundle->colorAttachmentCount;ai++){
                     device->functions.vkCmdSetViewport(executedBuffer, 0, 1, &ds.viewport   );
                     if(ds.scissorRect.extent.width != UINT32_MAX){
@@ -4871,12 +4871,12 @@ void recordVkCommand(CommandBufferAndSomeState* destination_, const RenderPassCo
                 }
             }
             device->functions.vkCmdDispatch(
-                destinationVk, 
-                dispatch->x, 
-                dispatch->y, 
+                destinationVk,
+                dispatch->x,
+                dispatch->y,
                 dispatch->z
             );
-            
+
         }
         break;
         case cp_command_type_dispatch_workgroups_indirect:{
@@ -4898,14 +4898,14 @@ void recordVkCommand(CommandBufferAndSomeState* destination_, const RenderPassCo
                     }
                 }
             }
-            
+
             const ComputePassCommandDispatchWorkgroupsIndirect* dispatch = &command->dispatchWorkgroupsIndirect;
 
             ce_trackBuffer(destination_->cmdEncoder, dispatch->buffer, (BufferUsageSnap){
                 .access = VK_ACCESS_INDIRECT_COMMAND_READ_BIT,
                 .stage  = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT
             });
-            
+
             device->functions.vkCmdDispatchIndirect(
                 destinationVk,
                 dispatch->buffer->buffer,
@@ -4943,7 +4943,7 @@ void recordVkCommand(CommandBufferAndSomeState* destination_, const RenderPassCo
         case rp_command_type_multi_draw_indirect:{
 
         }break;
-    
+
         case rp_command_type_set_force32: // fallthrough
         case rp_command_type_enum_count:  // fallthrough
         case rp_command_type_invalid: wgvk_assert(false, "Invalid command type"); rg_unreachable();
@@ -5124,7 +5124,7 @@ void generateInterspersedCompatibilityBarriers(WGPUCommandBuffer* buffers, uint3
                 barrierSets[bufferIndex].srcStage |= srcStage;
                 barrierSets[bufferIndex].dstStage |= kvp->value.initialStage;
                 VkImageMemoryBarrierVector_push_back(&barrierSets[bufferIndex].imageBarriers, imageBarrier);
-                if(knowledge){ 
+                if(knowledge){
                     knowledge->lastAccess              = kvp->value.lastAccess;
                     knowledge->lastStage               = kvp->value.lastStage;
                     knowledge->lastLayout              = kvp->value.lastLayout;
@@ -5173,7 +5173,7 @@ void generateInterspersedCompatibilityBarriers(WGPUCommandBuffer* buffers, uint3
                     .size = VK_WHOLE_SIZE
                 };
                 VkBufferMemoryBarrierVector_push_back(&barrierSets[bufferIndex].bufferBarriers, bufferBarrier);
-                if(knowledge){ 
+                if(knowledge){
                     knowledge->lastAccess              = kvp->value.lastAccess;
                     knowledge->lastStage               = kvp->value.lastStage;
                 }
@@ -5249,7 +5249,7 @@ static const char* il_string(VkImageLayout layout){
         case VK_IMAGE_LAYOUT_VIDEO_ENCODE_QUANTIZATION_MAP_KHR: return "VK_IMAGE_LAYOUT_VIDEO_ENCODE_QUANTIZATION_MAP_KHR";
         default: return " <Unknown Layout?> ";
     }
-} 
+}
 void wgpuQueueSubmit(WGPUQueue queue, size_t commandCount, const WGPUCommandBuffer* buffers){
     ENTRY();
 
@@ -5262,12 +5262,12 @@ void wgpuQueueSubmit(WGPUQueue queue, size_t commandCount, const WGPUCommandBuff
     WGPUCommandEncoder pscache = queue->presubmitCache;
     const uint32_t cacheBufferNonEmpty = ((pscache->encodedCommandCount > 0) ? 1 : 0);
     WGPUCommandBufferVector_initWithSize(&submittableWGPU, commandCount + cacheBufferNonEmpty);
-    
+
     WGPUCommandBufferDescriptor cbd = {
         .label = STRVIEW("PresubmitCache"),
     };
     WGPUCommandBuffer cachebuffer = wgpuCommandEncoderFinish(queue->presubmitCache, &cbd);
-    
+
     if(cacheBufferNonEmpty == 1){
         submittableWGPU.data[0] = cachebuffer;
     }
@@ -5288,7 +5288,7 @@ void wgpuQueueSubmit(WGPUQueue queue, size_t commandCount, const WGPUCommandBuff
     if(use_single_submit && submittableWGPU.size > 0){
         CmdBarrierSetILVector compatibilityBarrierSets;
         CmdBarrierSetILVector_initWithSize(&compatibilityBarrierSets, submittableWGPU.size);
-        
+
         generateInterspersedCompatibilityBarriers(submittableWGPU.data, submittableWGPU.size, compatibilityBarrierSets.data);
         for(uint32_t i = 0;i < submittableWGPU.size;i++){
             const CmdBarrierSet* cbs = CmdBarrierSetILVector_get(&compatibilityBarrierSets, i);
@@ -5374,7 +5374,7 @@ void wgpuQueueSubmit(WGPUQueue queue, size_t commandCount, const WGPUCommandBuff
             // compensated by not calling addRef below
             // wgpuCommandBufferRelease(interspersedBuffers.data[i]);
         }
-        
+
         RL_FREE(waitFlags);
     }
 
@@ -5382,7 +5382,7 @@ void wgpuQueueSubmit(WGPUQueue queue, size_t commandCount, const WGPUCommandBuff
 
         for(uint32_t i = 0;i < submittableWGPU.size;i++){
             WGPUCommandBuffer submittedBuffer = submittableWGPU.data[i];
-            BufferUsageRecordMap map = submittedBuffer->resourceUsage.referencedBuffers; 
+            BufferUsageRecordMap map = submittedBuffer->resourceUsage.referencedBuffers;
             for(size_t refbEntry = 0;refbEntry < map.current_capacity;refbEntry++){
                 const BufferUsageRecordMap_kv_pair* kv_pair = map.table + refbEntry;
                 WGPUBuffer keybuffer = kv_pair->key;
@@ -5401,14 +5401,14 @@ void wgpuQueueSubmit(WGPUQueue queue, size_t commandCount, const WGPUCommandBuff
                 }
             }
         }
-        
+
         WGPUCommandBufferVector insert;
         WGPUCommandBufferVector_init(&insert);
-        
+
         WGPUCommandBufferVector_push_back(&insert, cachebuffer);
-        
+
         // TODO IMPORTANT: Is this really not required here? wgpuCommandBufferAddRef(cachebuffer);
-        
+
 
         for(size_t i = 0;i < commandCount;i++){
             WGPUCommandBufferVector_push_back(&insert, buffers[i]);
@@ -5729,11 +5729,11 @@ WGPUStatus wgpuSurfaceGetCapabilities(WGPUSurface wgpuSurface, WGPUAdapter adapt
     VkSurfaceCapabilitiesKHR scap = {0};
     VkPhysicalDevice vk_physicalDevice = adapter->physicalDevice;
     vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vk_physicalDevice, surface, &scap);
-    
+
     // Formats
     uint32_t formatCount = 0;
     vkGetPhysicalDeviceSurfaceFormatsKHR(vk_physicalDevice, surface, &formatCount, NULL);
-    
+
     if (formatCount != 0 && wgpuSurface->formatCache == NULL) {
         wgpuSurface->formatCache = (VkSurfaceFormatKHR*)RL_CALLOC(formatCount, sizeof(VkSurfaceFormatKHR));
         wgpuSurface->wgpuFormatCache = (WGPUTextureFormat*)RL_CALLOC(formatCount, sizeof(WGPUTextureFormat));
@@ -5743,7 +5743,7 @@ WGPUStatus wgpuSurfaceGetCapabilities(WGPUSurface wgpuSurface, WGPUAdapter adapt
         for(size_t i = 0;i < formatCount;i++){
             wgpuSurface->formatCache[i] = surfaceFormats[i];
             //printf("[%s + %s]\n", colorSpaceString(surfaceFormats[i].colorSpace), vkFormatString(surfaceFormats[i].format));
-            
+
             if(surfaceFormats[i].colorSpace == spaceToScan && fromVulkanPixelFormat(surfaceFormats[i].format) != WGPUTextureFormat_Undefined){
                 wgpuSurface->wgpuFormatCache[wgpuSurface->wgpuFormatCount++] = fromVulkanPixelFormat(surfaceFormats[i].format);
             }
@@ -5850,8 +5850,8 @@ void wgpuSurfaceConfigure(WGPUSurface surface, const WGPUSurfaceConfiguration* c
         createInfo.minImageCount = SWAPCHAIN_ICLAMP_TEMP(vkCapabilities.minImageCount + 1, vkCapabilities.minImageCount, vkCapabilities.maxImageCount);
     }
     #undef SWAPCHAIN_ICLAMP_TEMP
-    
-    
+
+
     createInfo.imageFormat = toVulkanPixelFormat(config->format);//swapchainImageFormat;
     surface->width  = correctedWidth;
     surface->height = correctedHeight;
@@ -5863,7 +5863,7 @@ void wgpuSurfaceConfigure(WGPUSurface surface, const WGPUSurfaceConfiguration* c
 
     // Queue family indices
     uint32_t queueFamilyIndices[2] = {
-        device->adapter->queueIndices.graphicsIndex, 
+        device->adapter->queueIndices.graphicsIndex,
         device->adapter->queueIndices.transferIndex
     };
 
@@ -5879,7 +5879,7 @@ void wgpuSurfaceConfigure(WGPUSurface surface, const WGPUSurfaceConfiguration* c
     createInfo.imageColorSpace = toVulkanColorSpace(surface->colorSpace, surface->tonemappingMode);
     createInfo.preTransform = vkCapabilities.currentTransform;
     createInfo.compositeAlpha = toVulkanCompositeAlphaMode(config->alphaMode);
-    createInfo.presentMode = toVulkanPresentMode(config->presentMode); 
+    createInfo.presentMode = toVulkanPresentMode(config->presentMode);
     createInfo.clipped = VK_TRUE;
     createInfo.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     VkResult scCreateResult = device->functions.vkCreateSwapchainKHR(device->device, &createInfo, NULL, &(surface->swapchain));
@@ -5941,7 +5941,7 @@ void wgpuComputePassEncoderDispatchWorkgroups(WGPUComputePassEncoder cpe, uint32
         .type = cp_command_type_dispatch_workgroups,
         .dispatchWorkgroups = {x, y, z}
     };
-    
+
 
     RenderPassCommandGenericVector_push_back(&cpe->bufferedCommands, insert);
     EXIT();
@@ -5968,10 +5968,10 @@ void wgpuCommandEncoderRelease(WGPUCommandEncoder commandEncoder) {
             WGPURenderPassEncoderSet_for_each(&commandBuffer->referencedRPs, releaseRPSetCallback, NULL);
             WGPUComputePassEncoderSet_for_each(&commandBuffer->referencedCPs, releaseCPSetCallback, NULL);
             WGPURaytracingPassEncoderSet_for_each(&commandBuffer->referencedRTs, releaseRTSetCallback, NULL);
-            
+
             releaseAllAndClear(&commandBuffer->resourceUsage);
             // The above performs ResourceUsage_free already!
-            
+
 
             WGPURenderPassEncoderSet_free(&commandBuffer->referencedRPs);
             WGPUComputePassEncoderSet_free(&commandBuffer->referencedCPs);
@@ -5984,7 +5984,7 @@ void wgpuCommandEncoderRelease(WGPUCommandEncoder commandEncoder) {
             );
         }
     }
-    
+
     RL_FREE(commandEncoder);
     EXIT();
 }
@@ -5996,15 +5996,15 @@ void wgpuCommandBufferRelease(WGPUCommandBuffer commandBuffer) {
         WGPURenderPassEncoderSet_for_each(&commandBuffer->referencedRPs, releaseRPSetCallback, NULL);
         WGPUComputePassEncoderSet_for_each(&commandBuffer->referencedCPs, releaseCPSetCallback, NULL);
         WGPURaytracingPassEncoderSet_for_each(&commandBuffer->referencedRTs, releaseRTSetCallback, NULL);
-        
+
         releaseAllAndClear(&commandBuffer->resourceUsage);
         // The above performs ResourceUsage_free already!
-    
+
 
         WGPURenderPassEncoderSet_free(&commandBuffer->referencedRPs);
         WGPUComputePassEncoderSet_free(&commandBuffer->referencedCPs);
         WGPURaytracingPassEncoderSet_free(&commandBuffer->referencedRTs);
-        
+
         PerframeCache* frameCache = DeviceGetFIFCache(commandBuffer->device, commandBuffer->cacheIndex);
         device->functions.vkFreeCommandBuffers(device->device, frameCache->commandPool, 1, &commandBuffer->buffer);
         if(commandBuffer->label.data){
@@ -6171,7 +6171,7 @@ void wgpuBindGroupRelease(WGPUBindGroup dshandle) {
         // DONT delete them, they are cached
         // vkFreeDescriptorSets(dshandle->device->device, dshandle->pool, 1, &dshandle->set);
         // vkDestroyDescriptorPool(dshandle->device->device, dshandle->pool, NULL);
-        
+
         RL_FREE(dshandle);
     }
     EXIT();
@@ -6232,7 +6232,7 @@ void wgpuDeviceRelease(WGPUDevice device){
         wgpuCommandBufferRelease(cBuffer);
         FIFCache_destroy(&device->fifCache);
         {  // Destroy PerframeCaches
-            
+
             FenceCache_Destroy(&device->fenceCache);
             #if USE_VMA_ALLOCATOR == 1
             vmaDestroyPool(device->allocator, device->aligned_hostVisiblePool);
@@ -6241,7 +6241,7 @@ void wgpuDeviceRelease(WGPUDevice device){
             wgvkAllocator_destroy(&device->builtinAllocator);
         }
         device->functions.vkDestroyCommandPool(device->device, device->secondaryCommandPool, NULL);
-        
+
         wgpuQueueRelease(device->queue);
         wgpuAdapterRelease(device->adapter);
 
@@ -6254,7 +6254,7 @@ void wgpuDeviceRelease(WGPUDevice device){
         }
 
         device->functions.vkDestroyDevice(device->device, NULL);
-        
+
         // Still a lot to do
         RL_FREE(device->queue);
         RL_FREE(device);
@@ -6296,7 +6296,7 @@ WGPUComputePipeline wgpuDeviceCreateComputePipeline(WGPUDevice device, const WGP
     wgvk_assert(descriptor->compute.entryPoint.length < 511, "entryPoint name of the compute stage too long");
     memcpy(namebuffer, descriptor->compute.entryPoint.data, std_min_u32_(511, descriptor->compute.entryPoint.length));
     namebuffer[std_min_u32_(511, descriptor->compute.entryPoint.length)] = 0;
-    
+
     VkShaderModule vkModule = VK_NULL_HANDLE;
     if(descriptor->compute.module->vulkanModuleMultiEP){
         vkModule = descriptor->compute.module->vulkanModuleMultiEP;
@@ -6366,7 +6366,7 @@ WGPURenderPipeline wgpuDeviceCreateRenderPipeline(WGPUDevice device, const WGPUR
         (VkPipelineShaderStageCreateInfo){0}
     };
     uint32_t shaderStageInsertPos = 0;
-    
+
     // Vertex Stage
     VkPipelineShaderStageCreateInfo vertShaderStageInfo zeroinit;
     vertShaderStageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
@@ -6381,10 +6381,10 @@ WGPURenderPipeline wgpuDeviceCreateRenderPipeline(WGPUDevice device, const WGPUR
         // for(uint32_t i = 0;i < WGPUShaderStageEnum_EnumCount;i++){
         //     wgvk_assert(wgpuStrlen(descriptor->vertex.entryPoint) < 16, "Entry point name too long");
         //     size_t clength = wgpuStrlen(descriptor->vertex.entryPoint);
-        //     
+        //
         // }
     }
-    
+
     VkSpecializationInfo vertexSpecInfo = {0};
     float vertexConstantBuffer[32];
     VkSpecializationMapEntry vertexMapEntries[32];
@@ -6450,7 +6450,7 @@ WGPURenderPipeline wgpuDeviceCreateRenderPipeline(WGPUDevice device, const WGPUR
 
         for (size_t j = 0; j < layout->attributeCount; ++j) {
             const WGPUVertexAttribute* attrib = &layout->attributes[j];
-            
+
             attributeDescriptions[attributeDescriptionCount++] = (VkVertexInputAttributeDescription){
                 .location = attrib->shaderLocation,
                 .binding = currentBinding,
@@ -6515,15 +6515,15 @@ WGPURenderPipeline wgpuDeviceCreateRenderPipeline(WGPUDevice device, const WGPUR
     multisampling.alphaToOneEnable = VK_FALSE; // Basic case
 
     // Depth Stencil State (Optional)
-    bool stencilEnable = descriptor->depthStencil && 
-    ((descriptor->depthStencil->format == WGPUTextureFormat_Depth24PlusStencil8) ||  
+    bool stencilEnable = descriptor->depthStencil &&
+    ((descriptor->depthStencil->format == WGPUTextureFormat_Depth24PlusStencil8) ||
     (descriptor->depthStencil->format == WGPUTextureFormat_Depth32FloatStencil8));
     VkPipelineDepthStencilStateCreateInfo depthStencil zeroinit;
     depthStencil.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
     if (descriptor->depthStencil) {
         const WGPUDepthStencilState* ds = descriptor->depthStencil;
         depthStencil.depthTestEnable = VK_TRUE; // If struct exists, assume depth test is desired
-        depthStencil.depthWriteEnable = ds->depthWriteEnabled ? VK_TRUE : VK_FALSE;
+        depthStencil.depthWriteEnable = ds->depthWriteEnabled == WGPUOptionalBool_True ? VK_TRUE : VK_FALSE;
         depthStencil.depthCompareOp = toVulkanCompareFunction(ds->depthCompare);
         depthStencil.depthBoundsTestEnable = VK_FALSE; // Not in WGPU descriptor
         depthStencil.minDepthBounds = 0.0f;
@@ -6616,13 +6616,13 @@ WGPURenderPipeline wgpuDeviceCreateRenderPipeline(WGPUDevice device, const WGPUR
     if (depthStencil.stencilTestEnable) {
         dynamicStates[dynamicStateCount++] = VK_DYNAMIC_STATE_STENCIL_REFERENCE;
     }
-    
+
 
 
     VkPipelineDynamicStateCreateInfo dynamicState zeroinit;
     dynamicState.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
     dynamicState.dynamicStateCount = dynamicStateCount;
-    dynamicState.pDynamicStates = dynamicStates;   
+    dynamicState.pDynamicStates = dynamicStates;
     #if VULKAN_USE_DYNAMIC_RENDERING == 1
     VkRenderPass rprp = NULL;
     VkFormat cAttachmentFormats[MAX_COLOR_ATTACHMENTS];
@@ -6690,8 +6690,8 @@ WGPURenderPipeline wgpuDeviceCreateRenderPipeline(WGPUDevice device, const WGPUR
         .basePipelineHandle = VK_NULL_HANDLE, // Optional
         .basePipelineIndex = -1, // Optional
     };
-    
-    
+
+
 
 
     WGPURenderPipeline pipelineImpl = (WGPURenderPipeline)RL_CALLOC(1, sizeof(WGPURenderPipelineImpl));
@@ -6760,7 +6760,7 @@ void wgpuCommandEncoderCopyBufferToBuffer  (WGPUCommandEncoder commandEncoder, W
             .access = VK_ACCESS_TRANSFER_READ_BIT
         }
     );
-    
+
 
     const VkBufferCopy copy = {
         .srcOffset = sourceOffset,
@@ -6781,8 +6781,8 @@ void wgpuCommandEncoderCopyBufferToBuffer  (WGPUCommandEncoder commandEncoder, W
     //        VK_PIPELINE_STAGE_TRANSFER_BIT,
     //        VK_PIPELINE_STAGE_HOST_BIT,
     //        0,
-    //        1, &memoryBarrier, 
-    //        0, NULL, 
+    //        1, &memoryBarrier,
+    //        0, NULL,
     //        0, NULL
     //    );
     //}
@@ -6799,9 +6799,9 @@ void wgpuCommandEncoderCopyBufferToBuffer  (WGPUCommandEncoder commandEncoder, W
 }
 void wgpuCommandEncoderCopyBufferToTexture (WGPUCommandEncoder commandEncoder, const WGPUTexelCopyBufferInfo* source, const WGPUTexelCopyTextureInfo* destination, WGPUExtent3D const * copySize){
     ENTRY();
-    
+
     ++commandEncoder->encodedCommandCount;
-    
+
     const bool is3D = destination->texture->dimension == VK_IMAGE_TYPE_3D;
     const VkBufferImageCopy region = {
         .bufferOffset = source->layout.offset,
@@ -6822,7 +6822,7 @@ void wgpuCommandEncoderCopyBufferToTexture (WGPUCommandEncoder commandEncoder, c
             is3D ? copySize->depthOrArrayLayers : 1
         },
     };
-    
+
     ce_trackBuffer(commandEncoder, source->buffer, (BufferUsageSnap){VK_PIPELINE_STAGE_TRANSFER_BIT, VK_ACCESS_TRANSFER_READ_BIT});
     ce_trackTexture(commandEncoder, destination->texture, (ImageUsageSnap){
         .layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
@@ -7015,7 +7015,7 @@ void wgpuRenderPassEncoderDrawIndexed(WGPURenderPassEncoder rpe, uint32_t indice
 
     // Buffer the indexed draw command into the command buffer
     RenderPassEncoder_PushCommand(rpe, &insert);
-    
+
     //vkCmdDrawIndexed(rpe->secondaryCmdBuffer, indices, instances, firstindex, (int32_t)(baseVertex & 0x7fffffff), firstinstance);
     EXIT();
 }
@@ -7048,11 +7048,11 @@ void wgpuRenderPassEncoderSetBindGroup(WGPURenderPassEncoder rpe, uint32_t group
             dynamicOffsets
         }
     };
-    
+
     RenderPassEncoder_PushCommand(rpe, &insert);
-    
-    
-    
+
+
+
 
     for(uint32_t i = 0;i < group->entryCount;i++){
 
@@ -7070,7 +7070,7 @@ void wgpuRenderPassEncoderSetBindGroup(WGPURenderPassEncoder rpe, uint32_t group
         if(entry->textureView){
             const VkAccessFlags accessFlags = extractVkAccessFlags(group->layout->entries + i);
             const VkPipelineStageFlags stage = toVulkanPipelineStageBits(group->layout->entries[i].visibility) | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-            
+
             //VkImageLayout layout = (extractVkDescriptorType(group->layout->entries + i) == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) ? VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
             ce_trackTextureView(rpe->cmdEncoder, entry->textureView, (ImageUsageSnap){
@@ -7087,7 +7087,7 @@ void wgpuRenderPassEncoderSetBindGroup(WGPURenderPassEncoder rpe, uint32_t group
 
 void wgpuComputePassEncoderSetPipeline (WGPUComputePassEncoder cpe, WGPUComputePipeline computePipeline){
     ENTRY();
-    
+
     RenderPassCommandGeneric insert = {
         .type = cp_command_type_set_compute_pipeline,
         .setComputePipeline = {
@@ -7100,7 +7100,7 @@ void wgpuComputePassEncoderSetPipeline (WGPUComputePassEncoder cpe, WGPUComputeP
 }
 void wgpuComputePassEncoderSetBindGroup(WGPUComputePassEncoder cpe, uint32_t groupIndex, WGPUBindGroup group, size_t dynamicOffsetCount, const uint32_t* dynamicOffsets){
     ENTRY();
-    
+
     RenderPassCommandGeneric insert = {
         .type = rp_command_type_set_bind_group,
         .setBindGroup = {
@@ -7112,7 +7112,7 @@ void wgpuComputePassEncoderSetBindGroup(WGPUComputePassEncoder cpe, uint32_t gro
         }
     };
     cpe->bindGroups[groupIndex] = group;
-    
+
     //for(uint32_t i = 0;i < group->entryCount;i++){
     //    const WGPUBindGroupEntry* entry = &group->entries[i];
     //    if(entry->buffer){
@@ -7202,7 +7202,7 @@ void wgpuRaytracingPassEncoderEnd(WGPURaytracingPassEncoder rtPassEncoder){
             for(uint32_t bindingIndex = 0;bindingIndex < layout->entryCount;bindingIndex++){
 
                 wgvk_assert(group->entries[bindingIndex].binding == layout->entries[bindingIndex].binding, "Mismatch between layout and group, this will cause bugs.");
-                
+
                 const WGPUBindGroupEntry*       groupEntry  = &group ->entries[bindingIndex];
                 const WGPUBindGroupLayoutEntry* layoutEntry = &layout->entries[bindingIndex];
 
@@ -7298,7 +7298,7 @@ void wgpuSurfaceGetCurrentTexture(WGPUSurface surface, WGPUSurfaceTexture* surfa
     wgvk_assert(surfaceTexture, "surfaceTexture must be nonnull");
     wgvk_assert(surface, "surface must be nonnull");
     wgvk_assert(surface->device, "surface->device must be nonnull");
-    
+
     const size_t submittedframes = surface->device->submittedFrames;
     const uint32_t cacheIndex = submittedframes % framesInFlight;
     SyncState* syncState = DeviceGetSyncState(surface->device, cacheIndex);
@@ -7353,7 +7353,7 @@ WGPUStatus wgpuSurfacePresent(WGPUSurface surface){
     PendingCommandBufferMap* pcm = &frameCache->pendingCommandBuffers;
     SyncState* syncState = &frameCache->syncState;
     VkCommandBuffer transitionBuffer = frameCache->finalTransitionBuffer;
-    
+
     VkCommandBufferBeginInfo transitionBufferBeginInfo = {
         .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
         .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT
@@ -7384,7 +7384,7 @@ WGPUStatus wgpuSurfacePresent(WGPUSurface surface){
         0,
         0, NULL,
         0, NULL,
-        1, &finalBarrier  
+        1, &finalBarrier
     );
     surface->images[surface->activeImageIndex]->layout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
     device->functions.vkEndCommandBuffer(transitionBuffer);
@@ -7410,17 +7410,17 @@ WGPUStatus wgpuSurfacePresent(WGPUSurface surface){
         .pWaitSemaphores = waitSemaphores,
         .pSignalSemaphores = surface->presentSemaphores + surface->activeImageIndex
     };
-    
-    
+
+
     WGPUFence finalTransitionFence = frameCache->finalTransitionFence;
     wgpuFenceAddRef(finalTransitionFence);
     //printf("Submitting %p with fence %p\n", transitionBuffer, finalTransitionFence);
     device->functions.vkQueueSubmit(surface->device->queue->graphicsQueue, 1, &cbsinfo, finalTransitionFence->fence);
-    
+
     finalTransitionFence->state = WGPUFenceState_InUse;
-    
+
     WGPUCommandBufferVector* cmdBuffers = PendingCommandBufferMap_get(pcm, (void*)finalTransitionFence);
-    
+
     if(cmdBuffers == NULL){
         WGPUCommandBufferVector insert = {0};
         PendingCommandBufferMap_put(pcm, finalTransitionFence, insert);
@@ -7454,7 +7454,7 @@ void wgpuDeviceTick(WGPUDevice device){
     WGPUCommandBuffer buffer = wgpuCommandEncoderFinish(queue->presubmitCache, &cbd);
     wgpuCommandEncoderRelease(queue->presubmitCache);
     wgpuCommandBufferRelease(buffer);
-    
+
     {
         const uint32_t toBeFinishedCacheIndex = device->submittedFrames % framesInFlight;
         PerframeCache* frameCachetbf = DeviceGetFIFCache(device, toBeFinishedCacheIndex);
@@ -7464,13 +7464,13 @@ void wgpuDeviceTick(WGPUDevice device){
         const VkPipelineStageFlags waitmask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
         const uint32_t tsubmits = syncStatetbf->submits;
         WGPUCommandBufferVector* pendingForFTF = PendingCommandBufferMap_get(pcmtbf, frameCachetbf->finalTransitionFence);
-        
+
         if(pendingForFTF == NULL){
             // Only wait on a semaphore if work was actually submitted (tsubmits > 0).
             // If tsubmits == 0, semaphores[0] is unsignaled, causing VUID-vkQueueSubmit-pWaitSemaphores-03238.
             VkSemaphore* pWaitSem = NULL;
             uint32_t waitCount = 0;
-            
+
             if (tsubmits > 0) {
                 pWaitSem = VkSemaphoreVector_get(&syncStatetbf->semaphores, tsubmits);
                 waitCount = 1;
@@ -7482,7 +7482,7 @@ void wgpuDeviceTick(WGPUDevice device){
                 .pWaitSemaphores = pWaitSem,
                 .pWaitDstStageMask = &waitmask
             };
-            
+
             device->functions.vkQueueSubmit(device->queue->graphicsQueue, 1, &emptySubmit, frameCachetbf->finalTransitionFence->fence);
             wgpuFenceAddRef(frameCachetbf->finalTransitionFence);
             frameCachetbf->finalTransitionFence->state = WGPUFenceState_InUse;
@@ -7499,20 +7499,20 @@ void wgpuDeviceTick(WGPUDevice device){
             //WGPUCommandBufferVector_init(inserted);
         }
     }
-    
-    
+
+
     ++device->submittedFrames;
     #if USE_VMA_ALLOCATOR == 1
     vmaSetCurrentFrameIndex(device->allocator, device->submittedFrames % framesInFlight);
     #endif
-    
-    
+
+
 
     uint32_t cacheIndex = device->submittedFrames % framesInFlight;
     PerframeCache* frameCacheMew = DeviceGetFIFCache(device, cacheIndex);
     PendingCommandBufferMap* pcmNew = &frameCacheMew->pendingCommandBuffers;
     SyncState* syncStateNew = &frameCacheMew->syncState;
-    
+
     WGPUFenceVector fences;
     WGPUFenceVector_init(&fences);
 
@@ -7530,7 +7530,7 @@ void wgpuDeviceTick(WGPUDevice device){
         //TRACELOG(WGPU_LOG_INFO, "No fences!");
     }
 
-    PendingCommandBufferMap_for_each(pcmNew, resetFenceAndReleaseBuffers, device);    
+    PendingCommandBufferMap_for_each(pcmNew, resetFenceAndReleaseBuffers, device);
     WGPUFenceVector_free(&fences);
 
     WGPUBufferVector* usedBuffers = &frameCacheMew->usedBatchBuffers;
@@ -7544,10 +7544,10 @@ void wgpuDeviceTick(WGPUDevice device){
     }
     unusedBuffers->size += usedBuffers->size;
     WGPUBufferVector_clear(usedBuffers);//(WGPUBufferVector *dest, const WGPUBufferVector *source)
-    
 
-    
-    // These lines is currently commented out because they cause an 
+
+
+    // These lines is currently commented out because they cause an
     // issue with CommandEncoders living across wgpuDeviceTick (and wgpuSurfacePresent) calls
     //
     // VkCommandPool poolToClear = frameCacheMew->commandPool;
@@ -7615,7 +7615,7 @@ void wgpuRenderPassEncoderSetVertexBuffer(WGPURenderPassEncoder rpe, uint32_t sl
     RenderPassEncoder_PushCommand(rpe, &insert);
 
     ce_trackBuffer(rpe->cmdEncoder, buffer, (BufferUsageSnap){
-        .access =  VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT, 
+        .access =  VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT,
         .stage = VK_PIPELINE_STAGE_VERTEX_INPUT_BIT
     });
     EXIT();
@@ -7705,7 +7705,7 @@ void wgpuRenderPassEncoderSetIndexBuffer(WGPURenderPassEncoder rpe, WGPUBuffer b
     ENTRY();
     wgvk_assert(rpe != NULL, "RenderPassEncoderHandle is null");
     wgvk_assert(buffer != NULL, "BufferHandle is null");
-    
+
     RenderPassCommandGeneric insert = {
         .type = rp_command_type_set_index_buffer,
         .setIndexBuffer = {
@@ -7717,9 +7717,9 @@ void wgpuRenderPassEncoderSetIndexBuffer(WGPURenderPassEncoder rpe, WGPUBuffer b
     };
 
     RenderPassEncoder_PushCommand(rpe, &insert);
-    
+
     ce_trackBuffer(rpe->cmdEncoder, buffer, (BufferUsageSnap){
-        .stage = VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, 
+        .stage = VK_PIPELINE_STAGE_VERTEX_INPUT_BIT,
         .access = VK_ACCESS_INDEX_READ_BIT
     });
     EXIT();
@@ -7875,13 +7875,13 @@ static OptionalBarrier ru_trackTextureAndEmit(ResourceUsage* resourceUsage, WGPU
             texture->image,
             usage.subresource
         };
-        
+
         const VkPipelineStageFlags oldStage = alreadyThere->lastStage;
 
         alreadyThere->lastStage  = usage.stage;
         alreadyThere->lastAccess = usage.access;
         alreadyThere->lastLayout = usage.layout;
-        
+
         const OptionalBarrier ret = {
             .srcStage = oldStage,
             .dstStage = usage.stage,
@@ -7914,7 +7914,7 @@ static OptionalBarrier ru_trackTextureAndEmit(ResourceUsage* resourceUsage, WGPU
 
 static OptionalBarrier ru_trackTextureViewAndEmit(ResourceUsage* resourceUsage, WGPUTextureView view, ImageUsageSnap usage){
     ru_trackTextureView(resourceUsage, view);
-    
+
     ImageUsageRecord* alreadyThere = ImageUsageRecordMap_get(&resourceUsage->referencedTextures, view->texture);
     if(alreadyThere){
         const VkImageMemoryBarrier barr = {
@@ -7923,7 +7923,7 @@ static OptionalBarrier ru_trackTextureViewAndEmit(ResourceUsage* resourceUsage, 
             alreadyThere->lastAccess,
             usage.access,
             alreadyThere->lastLayout,
-            usage.layout, 
+            usage.layout,
             view->texture->device->adapter->queueIndices.graphicsIndex,
             view->texture->device->adapter->queueIndices.graphicsIndex,
             view->texture->image,
@@ -7935,7 +7935,7 @@ static OptionalBarrier ru_trackTextureViewAndEmit(ResourceUsage* resourceUsage, 
         alreadyThere->lastStage  = usage.stage;
         alreadyThere->lastAccess = usage.access;
         alreadyThere->lastLayout = usage.layout;
-        
+
         const OptionalBarrier ret = {
             .srcStage = oldStage,
             .dstStage = usage.stage,
@@ -7968,13 +7968,13 @@ static OptionalBarrier ru_trackTextureViewAndEmit(ResourceUsage* resourceUsage, 
 
 static OptionalBarrier ru_trackBufferAndEmit(ResourceUsage* resourceUsage, WGPUBuffer buffer, BufferUsageSnap usage){
     BufferUsageRecord* rec = BufferUsageRecordMap_get(&resourceUsage->referencedBuffers, buffer);
-    
+
     if(rec != NULL){
         const VkBufferMemoryBarrier bufferBarrier = {
             VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,
             NULL,
             rec->lastAccess,
-            usage.access, 
+            usage.access,
             buffer->device->adapter->queueIndices.graphicsIndex,
             buffer->device->adapter->queueIndices.graphicsIndex,
             buffer->buffer,
@@ -7990,7 +7990,7 @@ static OptionalBarrier ru_trackBufferAndEmit(ResourceUsage* resourceUsage, WGPUB
         rec->lastAccess = usage.access;
         rec->lastStage = usage.stage;
         rec->everWrittenTo |= isWritingAccess(usage.access);
-        
+
         return ret;
     }
     else{
@@ -8077,13 +8077,13 @@ RGAPI void ce_trackTexture(WGPUCommandEncoder encoder, WGPUTexture texture, Imag
 }
 
 RGAPI void ce_trackTextureView(WGPUCommandEncoder encoder, WGPUTextureView view, ImageUsageSnap usage){
-    
+
     //ru_trackTextureView(&enc->resourceUsage, view); TODO verify if that is actually taken care of
-    
+
     ru_trackAndEncodeTextureView(encoder, &encoder->resourceUsage, view, usage);
 }
 RGAPI void ce_trackBuffer(WGPUCommandEncoder encoder, WGPUBuffer buffer, BufferUsageSnap usage){
-    
+
     ru_trackAndEncodeBuffer(encoder, &encoder->resourceUsage, buffer, usage);
 }
 
@@ -8241,7 +8241,7 @@ WGPUGlobalReflectionInfo* getGlobalRI(SpvReflectShaderModule mod, uint32_t* coun
     wgvk_assert(descriptorSets != NULL, "Failed to allocate memory for descriptor set pointers");
     result = spvReflectEnumerateDescriptorSets(&mod, &descriptorSetCount, descriptorSets);
     wgvk_assert(result == SPV_REFLECT_RESULT_SUCCESS, "Failed to enumerate descriptor sets (pointers)");
-    
+
     uint32_t totalGlobalCount = 0;
     for(uint32_t i = 0; i < descriptorSetCount; i++){
         totalGlobalCount += descriptorSets[i]->binding_count;
@@ -8265,13 +8265,13 @@ WGPUGlobalReflectionInfo* getGlobalRI(SpvReflectShaderModule mod, uint32_t* coun
 
             insert.bindGroup = set->set; // Use the actual set number from reflection
             insert.binding = entry->binding;
-            
+
             const char* entry_name_ptr = entry->name ? entry->name : (entry->type_description->type_name ? entry->type_description->type_name : "");
             insert.name.data = entry_name_ptr;
             insert.name.length = strlen(entry_name_ptr);
             // insert.stageFlags = entry->shader_stage_flags; // If WGPUGlobalReflectionInfo has stage flags
 
-            switch(entry->descriptor_type){    
+            switch(entry->descriptor_type){
                 case SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
                     // insert.resourceType = WGPUBindingResourceType_Buffer; // If using a type enum for a union
                     insert.buffer.type = WGPUBufferBindingType_Uniform;
@@ -8310,7 +8310,7 @@ WGPUGlobalReflectionInfo* getGlobalRI(SpvReflectShaderModule mod, uint32_t* coun
             allGlobals[globalInsertIndex++] = insert;
         }
     }
-    
+
     RL_FREE((void*)descriptorSets); // Free the array of pointers (not the content they point to)
     return allGlobals;
 }
@@ -8375,7 +8375,7 @@ struct wgpuShaderModuleGetReflectionInfo_sync_userdata{
     WGPUReflectionInfoCallbackInfo callbackInfo;
 };
 WGPUReflectionAttribute spvReflectToWGPUReflectAttrib(SpvReflectInterfaceVariable* spvAttrib){
-    
+
     WGPUReflectionAttribute result = {0};
     result.location = spvAttrib->location;
     switch(spvAttrib->format){
@@ -8435,7 +8435,7 @@ static void wgpuShaderModuleGetReflectionInfo_sync(void* userdata_){
     ENTRY();
     struct wgpuShaderModuleGetReflectionInfo_sync_userdata* userdata = (struct wgpuShaderModuleGetReflectionInfo_sync_userdata*)userdata_;
     WGPUShaderModule module = userdata->module;
-    
+
     wgvk_assert(module,         "shaderModule is NULL");
     wgvk_assert(module->source, "shaderModule->source is NULL");
 
@@ -8445,13 +8445,13 @@ static void wgpuShaderModuleGetReflectionInfo_sync(void* userdata_){
 
             SpvReflectShaderModule mod zeroinit;
             SpvReflectResult result = spvReflectCreateShaderModule(spirvSource->codeSize, spirvSource->code, &mod);
-            
+
             if(result == SPV_REFLECT_RESULT_SUCCESS){
                 SpvReflectDescriptorSet* descriptorSets = NULL;
-                
+
                 WGPUReflectionInfo reflectionInfo zeroinit;
                 reflectionInfo.globals = getGlobalRI(mod,  &reflectionInfo.globalCount);
-                
+
                 SpvReflectInterfaceVariable** input_vars = NULL;
                 SpvReflectInterfaceVariable** output_vars = NULL;
 
@@ -8464,7 +8464,7 @@ static void wgpuShaderModuleGetReflectionInfo_sync(void* userdata_){
 
                 spvReflectEnumerateInputVariables(&mod, &input_var_count, input_vars);
                 spvReflectEnumerateOutputVariables(&mod, &output_var_count, output_vars);
-                
+
                 WGPUAttributeReflectionInfo input_attribute_info = {0};
                 WGPUAttributeReflectionInfo output_attribute_info = {0};
 
@@ -8472,7 +8472,7 @@ static void wgpuShaderModuleGetReflectionInfo_sync(void* userdata_){
                 output_attribute_info.attributeCount = output_var_count;
                 input_attribute_info.attributes = RL_CALLOC(input_attribute_info.attributeCount, sizeof(WGPUReflectionAttribute));
                 output_attribute_info.attributes = RL_CALLOC(output_attribute_info.attributeCount, sizeof(WGPUReflectionAttribute));
-                
+
                 for(uint32_t i = 0;i < input_var_count;i++){
                     SpvReflectInterfaceVariable* input_var_i = input_vars[i];
                     input_attribute_info.attributes[i] = spvReflectToWGPUReflectAttrib(input_var_i);
@@ -8551,7 +8551,7 @@ WGPUFuture wgpuShaderModuleGetReflectionInfo(WGPUShaderModule shaderModule, WGPU
         .userdataForFunction = udff,
         .freeUserData = RL_FREE
     };
-    WGPUFuture rete = { 
+    WGPUFuture rete = {
         atomic_fetch_add_explicit(&shaderModule->device->adapter->instance->currentFutureId, 1, memory_order_relaxed)
     };
     FutureIDMap_put(&instance->g_futureIDMap, rete.id, ret);
@@ -8658,7 +8658,7 @@ void wgpuAdapterGetFeatures(WGPUAdapter adapter, WGPUSupportedFeatures* features
     if (props.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) {
         supported_features[count++] = WGPUFeatureName_Depth32FloatStencil8;
     }
-    
+
     vkGetPhysicalDeviceFormatProperties(adapter->physicalDevice, VK_FORMAT_B10G11R11_UFLOAT_PACK32, &props);
     if (props.optimalTilingFeatures & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT) {
         supported_features[count++] = WGPUFeatureName_RG11B10UfloatRenderable;
@@ -8673,7 +8673,7 @@ void wgpuAdapterGetFeatures(WGPUAdapter adapter, WGPUSupportedFeatures* features
     if (props.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT) {
         supported_features[count++] = WGPUFeatureName_Float32Filterable;
     }
-    
+
     vkGetPhysicalDeviceFormatProperties(adapter->physicalDevice, VK_FORMAT_R32G32B32A32_SFLOAT, &props);
     if (props.optimalTilingFeatures & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT) {
         supported_features[count++] = WGPUFeatureName_Float32Blendable;
@@ -8815,7 +8815,7 @@ WGPUStatus wgpuBufferWriteMappedRange(WGPUBuffer buffer, size_t offset, const vo
 // Stubs for missing Methods of CommandBuffer
 void wgpuCommandBufferSetLabel(WGPUCommandBuffer commandBuffer, WGPUStringView label) {
     ENTRY();
-    
+
     EXIT();
 }
 void wgpuCommandBufferAddRef(WGPUCommandBuffer commandBuffer) {
@@ -8857,7 +8857,7 @@ void wgpuCommandEncoderResolveQuerySet(WGPUCommandEncoder commandEncoder, WGPUQu
         commandEncoder->buffer,
         querySet->queryPool,
         firstQuery,
-        queryCount, 
+        queryCount,
         destination->buffer,
         destinationOffset,
         8,
@@ -8988,7 +8988,7 @@ WGPUQuerySet wgpuDeviceCreateQuerySet(WGPUDevice device, const WGPUQuerySetDescr
         .queryType = toVulkanQueryType(descriptor->type),
         .queryCount = descriptor->count,
     };
-    
+
     VkResult qcr = device->functions.vkCreateQueryPool(device->device, &qpci, NULL, &ret->queryPool);
     if(qcr != VK_SUCCESS){
         RL_FREE(ret);
@@ -9261,7 +9261,7 @@ WGPUFuture wgpuDeviceCreateRenderPipelineAsync(WGPUDevice device, const WGPURend
     crps->device = device;
     crps->rpdesc = copyRenderPipelineDescriptor(descriptor);
     wgvk_thread_create(&crps->thread, wgpuDeviceCreateRenderPipelineAsync_sync, (void*)crps);
-    
+
     WGPUFutureImpl* futureImpl = RL_CALLOC(1, sizeof(WGPUFutureImpl));
     futureImpl->freeUserData = RL_FREE;
 
@@ -9269,7 +9269,7 @@ WGPUFuture wgpuDeviceCreateRenderPipelineAsync(WGPUDevice device, const WGPURend
 
 
     EXIT();
-    return (WGPUFuture){ futureID };                                                                                                                                                                              
+    return (WGPUFuture){ futureID };
 }
 void wgpuDeviceDestroy(WGPUDevice device) {
     ENTRY();
@@ -9441,18 +9441,20 @@ static void processWorkDoneFuture(void* userdata) {
     wgpuFenceWait(state->fence, UINT64_MAX);
 
     WGPUFenceState finalState = atomic_load_explicit(&state->fence->state, memory_order_acquire);
-    
+
     if (finalState == WGPUFenceState_Finished) {
         if (state->callbackInfo.callback) {
-            state->callbackInfo.callback(WGPUQueueWorkDoneStatus_Success, 
-                                         state->callbackInfo.userdata1, 
+            state->callbackInfo.callback(WGPUQueueWorkDoneStatus_Success,
+                                         (WGPUStringView){"", 0},
+                                         state->callbackInfo.userdata1,
                                          state->callbackInfo.userdata2);
         }
     } else {
         // Something went terribly wrong
         if (state->callbackInfo.callback) {
-            state->callbackInfo.callback(WGPUQueueWorkDoneStatus_Error, 
-                                         state->callbackInfo.userdata1, 
+            state->callbackInfo.callback(WGPUQueueWorkDoneStatus_Error,
+                                         (WGPUStringView){"", 0},
+                                         state->callbackInfo.userdata1,
                                          state->callbackInfo.userdata2);
         }
     }
@@ -9461,9 +9463,9 @@ static void processWorkDoneFuture(void* userdata) {
 static void freeWorkDoneFutureState(void* userdata) {
     if (!userdata) return;
     WorkDoneFutureState* state = (WorkDoneFutureState*)userdata;
-    
+
     wgpuFenceRelease(state->fence);
-    
+
     RL_FREE(state);
 }
 
@@ -9474,12 +9476,15 @@ WGPUFuture wgpuQueueOnSubmittedWorkDone(WGPUQueue queue, WGPUQueueWorkDoneCallba
     WGPUFence fence = wgpuDeviceCreateFence(queue->device);
     if (!fence) {
         if (callbackInfo.callback) {
-            callbackInfo.callback(WGPUQueueWorkDoneStatus_Error, callbackInfo.userdata1, callbackInfo.userdata2);
+            callbackInfo.callback(WGPUQueueWorkDoneStatus_Error,
+                                  (WGPUStringView){"", 0},
+                                  callbackInfo.userdata1,
+                                  callbackInfo.userdata2);
         }
         return (WGPUFuture){0};
     }
 
-    
+
     // TODO: This function works correctly as-is, but it is suboptimal so submit an empty batch
     // Just to get a fence. One could also reuse the latest fence used from that queue
     const VkSubmitInfo submitInfo = {
@@ -9495,11 +9500,14 @@ WGPUFuture wgpuQueueOnSubmittedWorkDone(WGPUQueue queue, WGPUQueueWorkDoneCallba
     if (result != VK_SUCCESS) {
         wgpuFenceRelease(fence);
         if (callbackInfo.callback) {
-            callbackInfo.callback(WGPUQueueWorkDoneStatus_Error, callbackInfo.userdata1, callbackInfo.userdata2);
+            callbackInfo.callback(WGPUQueueWorkDoneStatus_Error,
+                                  (WGPUStringView){"", 0},
+                                  callbackInfo.userdata1,
+                                  callbackInfo.userdata2);
         }
         return (WGPUFuture){0};
     }
-    
+
     atomic_store_explicit(&fence->state, WGPUFenceState_InUse, memory_order_release);
     WorkDoneFutureState* futureState = RL_CALLOC(1, sizeof(WorkDoneFutureState));
     futureState->fence = fence;
@@ -9513,10 +9521,10 @@ WGPUFuture wgpuQueueOnSubmittedWorkDone(WGPUQueue queue, WGPUQueueWorkDoneCallba
         .functionCalledOnWaitAny = processWorkDoneFuture,
         .freeUserData = freeWorkDoneFutureState
     };
-    
+
     uint64_t futureID = atomic_fetch_add_explicit(&instance->currentFutureId, 1, memory_order_relaxed);
     FutureIDMap_put(&instance->g_futureIDMap, futureID, futureImpl);
-    
+
     EXIT();
     return (WGPUFuture){ .id = futureID };
 }
@@ -9588,12 +9596,12 @@ void wgpuRenderPassEncoderEndOcclusionQuery(WGPURenderPassEncoder renderPassEnco
 }
 
 static inline size_t WGPUStringView_length(WGPUStringView view){
-    return (view.length == WGPU_STRLEN) ? strlen(view.data) : view.length; 
+    return (view.length == WGPU_STRLEN) ? strlen(view.data) : view.length;
 }
 
 void wgpuRenderPassEncoderInsertDebugMarker(WGPURenderPassEncoder renderPassEncoder, WGPUStringView markerLabel) {
     ENTRY();
-    
+
     size_t length = WGPUStringView_length(markerLabel);
     wgvk_assert(length <= 30, "Debug marker labels can't be longer than 30 chars");
 
@@ -10302,7 +10310,7 @@ RGAPI void wgvkAllocator_free(const wgvkAllocation* allocation) {
 
 /**
  * @brief Portable "yield" function
- * 
+ *
  */
 static inline void wgvk_cpu_relax(void) {
 #if defined(WGVK_OS_WINDOWS)
@@ -10345,13 +10353,13 @@ static void store_return_value(HANDLE handle, void* retval) {
     wgvk_assert(win32thread_registry_initialized, "Thread registry not initialized");
 
     EnterCriticalSection(&registry_lock);
-    
+
     win32_thread_entry_t* entry_for_handle = Win32ThreadHandleRegistry_get(&global_win32_thread_registry, (void*)handle);
     wgvk_assert(entry_for_handle != NULL, "Thread handle nonexistent in global_win32_thread_registry");
     if(entry_for_handle){
         entry_for_handle->return_value = retval;
     }
-    
+
     LeaveCriticalSection(&registry_lock);
 }
 
@@ -10367,14 +10375,14 @@ static void init_registry(void) {
 static int register_thread(HANDLE handle) {
     init_registry();
     EnterCriticalSection(&registry_lock);
-    
+
     win32_thread_entry_t value = {
         .handle = handle,
         .return_value = NULL,
         .in_use = 1,
     };
     Win32ThreadHandleRegistry_put(&global_win32_thread_registry, handle, value);
-    
+
     LeaveCriticalSection(&registry_lock);
     return -1;  // Registry full
 }
@@ -10383,35 +10391,35 @@ static DWORD WINAPI wgvk_thread_trampoline(LPVOID arg) {
 
     win32_thread_data_t* data = (win32_thread_data_t*)arg;
     void* retval = data->func(data->arg);
-    
+
     store_return_value(data->thread_handle, retval);
     free(data);
     return 0;
 }
 
 int wgvk_thread_create(wgvk_thread_t* thread, wgvk_thread_func_t func, void* arg) {
-    
+
     win32_thread_data_t* data = malloc(sizeof(win32_thread_data_t));
     if (!data) return -1;
-    
+
     data->func = func;
     data->arg = arg;
-    
+
     HANDLE handle = CreateThread(NULL, 0, wgvk_thread_trampoline, data, CREATE_SUSPENDED, NULL);
     if (!handle) {
         free(data);
         return -1;
     }
-    
+
     data->thread_handle = handle;
-    
+
     if (register_thread(handle) < 0) {
         TerminateThread(handle, 0);
         CloseHandle(handle);
         free(data);
         return -1;
     }
-    
+
     ResumeThread(handle);  // Start the thread
     thread->handle = handle;
     return 0;
@@ -10420,14 +10428,14 @@ int wgvk_thread_create(wgvk_thread_t* thread, wgvk_thread_func_t func, void* arg
 static void* get_return_value(HANDLE handle) {
     wgvk_assert(win32thread_registry_initialized, "Thread registry not initialized");
     void* retval = NULL;
-    
+
     EnterCriticalSection(&registry_lock);
     win32_thread_entry_t* entry_for_handle = Win32ThreadHandleRegistry_get(&global_win32_thread_registry, handle);
     wgvk_assert(entry_for_handle != NULL, "Thread handle nonexistent in global_win32_thread_registry");
-    
+
     retval = entry_for_handle->return_value;
     Win32ThreadHandleRegistry_erase(&global_win32_thread_registry, handle);
-    
+
     LeaveCriticalSection(&registry_lock);
     return retval;
 }
@@ -10436,13 +10444,13 @@ int wgvk_thread_join(wgvk_thread_t* thread, void** result) {
 
     DWORD retCode = WaitForSingleObject(thread, INFINITE);
     if (retCode != WAIT_OBJECT_0) return -1;
-    
+
     if (result) {
         *result = get_return_value(thread);
     } else {
         get_return_value(thread);  // Still need to clean up registry
     }
-    
+
     CloseHandle(thread);
     return 0;
 }
@@ -10945,9 +10953,9 @@ void wgvk_job_destroy(wgvk_job_t* job) {
 
 
 RGAPI void releaseAllAndClear(ResourceUsage* resourceUsage){
-    BufferUsageRecordMap_for_each(&resourceUsage->referencedBuffers, bufferReleaseCallback, NULL); 
-    ImageUsageRecordMap_for_each(&resourceUsage->referencedTextures, textureReleaseCallback, NULL); 
-    ImageViewUsageSet_for_each(&resourceUsage->referencedTextureViews, textureViewReleaseCallback, NULL); 
+    BufferUsageRecordMap_for_each(&resourceUsage->referencedBuffers, bufferReleaseCallback, NULL);
+    ImageUsageRecordMap_for_each(&resourceUsage->referencedTextures, textureReleaseCallback, NULL);
+    ImageViewUsageSet_for_each(&resourceUsage->referencedTextureViews, textureViewReleaseCallback, NULL);
     BindGroupUsageSet_for_each(&resourceUsage->referencedBindGroups, bindGroupReleaseCallback, NULL);
     BindGroupLayoutUsageSet_for_each(&resourceUsage->referencedBindGroupLayouts, bindGroupLayoutReleaseCallback, NULL);
     SamplerUsageSet_for_each(&resourceUsage->referencedSamplers, samplerReleaseCallback, NULL);
@@ -11022,7 +11030,7 @@ WGPURayTracingShaderBindingTable wgpuDeviceCreateRayTracingShaderBindingTable(WG
     for(uint32_t i = 0;i < descriptor->groupCount;i++){
         const WGPURayTracingShaderBindingTableGroupDescriptor* group_i = descriptor->groups + i;
         const VkRayTracingShaderGroupTypeKHR vkShaderGroupType = toVulkanShaderGroupType(group_i->type);
-        
+
         VkRayTracingShaderGroupCreateInfoKHR insert = {
             .sType = VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_KHR,
             .type = vkShaderGroupType,
@@ -11081,9 +11089,9 @@ WGPURaytracingPipeline wgpuDeviceCreateRayTracingPipeline(WGPUDevice device, con
         .stageCount = descriptor->rayTracingState.shaderBindingTable->shaderStageCount,
         .pStages    = descriptor->rayTracingState.shaderBindingTable->shaderStages,
     };
-    
+
     VkResult plCreateResult = device->functions.vkCreateRayTracingPipelinesKHR(device->device, VK_NULL_HANDLE, VK_NULL_HANDLE, 1, &createInfo, NULL, &ret->raytracingPipeline);
-    
+
     if(plCreateResult != VK_SUCCESS){
         RL_FREE(ret);
         return NULL;
@@ -11093,11 +11101,11 @@ WGPURaytracingPipeline wgpuDeviceCreateRayTracingPipeline(WGPUDevice device, con
     const uint32_t handleSize = rtProperties->shaderGroupHandleSize;
     const uint32_t baseAlignment = rtProperties->shaderGroupBaseAlignment;
     const uint32_t groupCount = descriptor->rayTracingState.shaderBindingTable->shaderGroupCount;
-    const uint32_t sbtStride = roundup_to_multiple(handleSize, baseAlignment); 
+    const uint32_t sbtStride = roundup_to_multiple(handleSize, baseAlignment);
 
     uint32_t packedSize = groupCount * handleSize;
     uint8_t* tempPackedHandles = (uint8_t*)RL_CALLOC(1, packedSize);
-    
+
     VkResult result = device->functions.vkGetRayTracingShaderGroupHandlesKHR(
         device->device,
         ret->raytracingPipeline,
@@ -11119,13 +11127,13 @@ WGPURaytracingPipeline wgpuDeviceCreateRayTracingPipeline(WGPUDevice device, con
     WGPUBufferDescriptor sbtBufferDesc = {
         .size = sbtTotalSize,
         .usage = WGPUBufferUsage_Raytracing | WGPUBufferUsage_ShaderDeviceAddress | WGPUBufferUsage_CopyDst,
-        .mappedAtCreation = true 
+        .mappedAtCreation = true
     };
-    
+
     ret->sbtBuffer = wgpuDeviceCreateBuffer(device, &sbtBufferDesc);
-    
+
     uint8_t* mappedSbtData = (uint8_t*)wgpuBufferGetMappedRange(ret->sbtBuffer, 0, sbtTotalSize);
-    
+
     for(size_t i = 0; i < groupCount; i++) {
         uint8_t* src = tempPackedHandles + (i * (size_t)handleSize);
         uint8_t* dst = mappedSbtData + (i * (size_t)sbtStride);
@@ -11133,7 +11141,7 @@ WGPURaytracingPipeline wgpuDeviceCreateRayTracingPipeline(WGPUDevice device, con
     }
 
     wgpuBufferUnmap(ret->sbtBuffer);
-    
+
     RL_FREE(tempPackedHandles);
     EXIT();
     return ret;
@@ -11144,26 +11152,26 @@ WGPURayTracingAccelerationContainer wgpuDeviceCreateRayTracingAccelerationContai
     WGPURayTracingAccelerationContainer ret = RL_CALLOC(1, sizeof(WGPURayTracingAccelerationContainerImpl));
     ret->level = descriptor->level;
     ret->device = device;
-    
+
     // For BLAS, geometryCount is the number of meshes.
     // For TLAS, geometryCount is 1 (A single geometry of type INSTANCES containing N primitives).
     uint32_t geometryCount = (descriptor->level == WGPURayTracingAccelerationContainerLevel_Bottom) ? descriptor->geometryCount : 1;
-    
+
     ret->geometryCount = geometryCount;
     ret->primitiveCounts = RL_CALLOC(geometryCount, sizeof(uint32_t));
     uint32_t* maxPrimitiveCounts = ret->primitiveCounts;
-    
+
     // Allocate geometries and range infos based on the corrected geometryCount
     VkAccelerationStructureGeometryKHR* geometries = RL_CALLOC(geometryCount, sizeof(VkAccelerationStructureGeometryKHR));
     ret->buildRangeInfos = (VkAccelerationStructureBuildRangeInfoKHR*)RL_CALLOC(geometryCount, sizeof(VkAccelerationStructureBuildRangeInfoKHR));
-    
+
     if (descriptor->level == WGPURayTracingAccelerationContainerLevel_Bottom) {
         ret->inputGeometryBuffers = (WGPUBuffer*)RL_CALLOC(geometryCount, sizeof(WGPUBuffer));
 
         for (uint32_t i = 0; i < geometryCount; i++) {
             geometries[i].sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
             geometries[i].flags = VK_GEOMETRY_OPAQUE_BIT_KHR;
-            
+
             switch (descriptor->geometries[i].type) {
                 case WGPURayTracingAccelerationGeometryType_Triangles: {
                     geometries[i].geometryType = VK_GEOMETRY_TYPE_TRIANGLES_KHR;
@@ -11173,7 +11181,7 @@ WGPURayTracingAccelerationContainer wgpuDeviceCreateRayTracingAccelerationContai
                     geometries[i].geometry.triangles.vertexData.deviceAddress = address;
                     geometries[i].geometry.triangles.vertexStride = descriptor->geometries[i].vertex.stride;
                     geometries[i].geometry.triangles.maxVertex = descriptor->geometries[i].vertex.count;
-                    
+
                     if (descriptor->geometries[i].index.buffer) {
                         geometries[i].geometry.triangles.indexType = toVulkanIndexFormat(descriptor->geometries[i].index.format);
                         ret->inputGeometryBuffers[i] = descriptor->geometries[i].index.buffer;
@@ -11225,19 +11233,19 @@ WGPURayTracingAccelerationContainer wgpuDeviceCreateRayTracingAccelerationContai
         };
 
         ret->instanceBuffer = wgpuDeviceCreateBuffer(device, &vfbDesc);
-        
+
         // 1. Loop through instances to fill the buffer data
         for(uint32_t i = 0; i < descriptor->instanceCount; i++){
             const WGPURayTracingAccelerationInstanceDescriptor* wgpuInstance = descriptor->instances + i;
             VkAccelerationStructureInstanceKHR* vulkanInstance = vulkanInstances + i;
-            
+
             memcpy(&vulkanInstance->transform, &wgpuInstance->transformMatrix, sizeof(VkTransformMatrixKHR));
-            
+
             vulkanInstance->instanceCustomIndex = wgpuInstance->instanceId;
             vulkanInstance->mask = wgpuInstance->mask;
             vulkanInstance->instanceShaderBindingTableRecordOffset = wgpuInstance->instanceOffset;
             vulkanInstance->flags = 0;
-            
+
             if (wgpuInstance->usage & WGPURayTracingAccelerationInstanceUsage_TriangleCullDisable) {
                 vulkanInstance->flags |= VK_GEOMETRY_INSTANCE_TRIANGLE_FACING_CULL_DISABLE_BIT_KHR;
             }
@@ -11248,7 +11256,7 @@ WGPURayTracingAccelerationContainer wgpuDeviceCreateRayTracingAccelerationContai
             };
             vulkanInstance->accelerationStructureReference = device->functions.vkGetAccelerationStructureDeviceAddressKHR(device->device, &getASDeviceAddressInfo);
         }
-        
+
         // Write the instance data to GPU memory
         wgpuQueueWriteBuffer(device->queue, ret->instanceBuffer, 0, vulkanInstances, vfbDesc.size);
         RL_FREE(vulkanInstances); // Clean up temp host memory
@@ -11263,12 +11271,12 @@ WGPURayTracingAccelerationContainer wgpuDeviceCreateRayTracingAccelerationContai
         geometries[0].geometry.instances.data.deviceAddress = ret->instanceBuffer->address;
         geometries[0].geometry.instances.arrayOfPointers = VK_FALSE;
 
-        ret->buildRangeInfos[0].primitiveCount = descriptor->instanceCount; 
+        ret->buildRangeInfos[0].primitiveCount = descriptor->instanceCount;
         ret->buildRangeInfos[0].primitiveOffset = 0;
         ret->buildRangeInfos[0].firstVertex = 0;
         ret->buildRangeInfos[0].transformOffset = 0;
     }
-    
+
     ret->geometries = geometries;
 
     VkAccelerationStructureBuildGeometryInfoKHR geometryInfoVulkan = {
@@ -11282,7 +11290,7 @@ WGPURayTracingAccelerationContainer wgpuDeviceCreateRayTracingAccelerationContai
     VkAccelerationStructureBuildSizesInfoKHR buildSizesInfo = {
         VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR
     };
-    
+
     device->functions.vkGetAccelerationStructureBuildSizesKHR(
         device->device,
         VK_ACCELERATION_STRUCTURE_BUILD_TYPE_HOST_OR_DEVICE_KHR,
@@ -11290,7 +11298,7 @@ WGPURayTracingAccelerationContainer wgpuDeviceCreateRayTracingAccelerationContai
         maxPrimitiveCounts, // For TLAS, this array has length 1, and the value is instanceCount
         &buildSizesInfo
     );
-    
+
     ret->accelerationStructureBuffer = wgpuDeviceCreateBuffer(device, &(WGPUBufferDescriptor){
         .size = buildSizesInfo.accelerationStructureSize,
         .usage = WGPUBufferUsage_Raytracing
@@ -11327,13 +11335,13 @@ WGPURayTracingAccelerationContainer wgpuDeviceCreateRayTracingAccelerationContai
     if(casResult != VK_SUCCESS){
         return NULL;
     }
-    
+
     // Update the geometry info with the created AS handle for future use (e.g. building)
     geometryInfoVulkan.dstAccelerationStructure = ret->accelerationStructure;
-    // NOTE: Do not overwrite geometryCount with descriptor->geometryCount here, 
+    // NOTE: Do not overwrite geometryCount with descriptor->geometryCount here,
     // strictly keep the calculated variable which is 1 for TLAS.
-    // geometryInfoVulkan.geometryCount = geometryCount; 
-    
+    // geometryInfoVulkan.geometryCount = geometryCount;
+
     wgpuDeviceAddRef(device);
     return ret;
     EXIT();
@@ -11341,9 +11349,9 @@ WGPURayTracingAccelerationContainer wgpuDeviceCreateRayTracingAccelerationContai
 
 void wgpuCommandEncoderBuildRayTracingAccelerationContainer(WGPUCommandEncoder encoder, WGPURayTracingAccelerationContainer container){
     ENTRY();
-    
+
     WGPUDevice device = encoder->device;
-    
+
     if(container->level == WGPURayTracingAccelerationContainerLevel_Top){
         if (container->instanceBuffer) {
             BufferUsageSnap instanceSnap = {
@@ -11765,7 +11773,7 @@ size_t vkFormatSize(VkFormat format){
 }
 
 const char* vkErrorString(int code){
-    
+
     switch(code){
         case VK_NOT_READY: return "VK_NOT_READY";
         case VK_TIMEOUT: return "VK_TIMEOUT";

--- a/tests/wgvk_unit_tests.cpp
+++ b/tests/wgvk_unit_tests.cpp
@@ -41,7 +41,7 @@ protected:
 
         WGPURequestAdapterOptions options = {};
         options.powerPreference = WGPUPowerPreference_HighPerformance;
-        
+
         struct AdapterCtx {
             WGPUAdapter adapter = nullptr;
             bool done = false;
@@ -62,12 +62,12 @@ protected:
         callbackInfo.userdata1 = &adapterCtx;
 
         WGPUFuture future = wgpuInstanceRequestAdapter(instance, &options, callbackInfo);
-        
+
         WGPUFutureWaitInfo waitInfo = { future, 0 };
         while(!adapterCtx.done) {
             wgpuInstanceWaitAny(instance, 1, &waitInfo, 1000000000); // 1 sec timeout
         }
-        
+
         adapter = adapterCtx.adapter;
         ASSERT_NE(adapter, nullptr) << "Failed to obtain WGPUAdapter";
 
@@ -92,9 +92,9 @@ protected:
 
         WGPUDeviceDescriptor devDesc = {};
         devDesc.label = { "TestDevice", 10 };
-        
+
         future = wgpuAdapterRequestDevice(adapter, &devDesc, devCbInfo);
-        
+
         waitInfo = { future, 0 };
         while(!deviceCtx.done) {
             wgpuInstanceWaitAny(instance, 1, &waitInfo, 1000000000);
@@ -134,15 +134,15 @@ TEST_F(WebGPUTest, BufferReferenceCounting) {
     ASSERT_NE(buffer, nullptr);
 
     // Initial RefCount should be 1
-    wgpuBufferAddRef(buffer); 
+    wgpuBufferAddRef(buffer);
     ASSERT_EQ(buffer->refCount, 2);
-    
+
     wgpuBufferRelease(buffer);
     // RefCount should be 1
     ASSERT_EQ(buffer->refCount, 1);
     wgpuBufferRelease(buffer);
     // RefCount should be 0, memory freed.
-    // Note: Can't easily verify memory free without mocking free(), 
+    // Note: Can't easily verify memory free without mocking free(),
     // but ASan will catch double-free or leaks here.
 }
 
@@ -151,11 +151,11 @@ TEST_F(WebGPUTest, BindGroupKeepsLayoutAlive) {
     entry.binding = 0;
     entry.visibility = WGPUShaderStage_Compute;
     entry.buffer.type = WGPUBufferBindingType_Storage;
-    
+
     WGPUBindGroupLayoutDescriptor bglDesc = {};
     bglDesc.entryCount = 1;
     bglDesc.entries = &entry;
-    
+
     WGPUBindGroupLayout layout = wgpuDeviceCreateBindGroupLayout(device, &bglDesc);
     ASSERT_NE(layout, nullptr);
 
@@ -184,7 +184,7 @@ TEST_F(WebGPUTest, BindGroupKeepsLayoutAlive) {
 
     // This should trigger the final release of the layout.
     wgpuBindGroupRelease(bindGroup);
-    
+
     wgpuBufferRelease(buffer);
 }
 
@@ -195,7 +195,7 @@ TEST_F(WebGPUTest, BufferMappingWrite) {
     desc.mappedAtCreation = false;
 
     WGPUBuffer buffer = wgpuDeviceCreateBuffer(device, &desc);
-    
+
     struct MapCtx {
         bool done = false;
         WGPUMapAsyncStatus status;
@@ -213,7 +213,7 @@ TEST_F(WebGPUTest, BufferMappingWrite) {
     cbInfo.mode = WGPUCallbackMode_WaitAnyOnly;
 
     WGPUFuture future = wgpuBufferMapAsync(buffer, WGPUMapMode_Write, 0, 64, cbInfo);
-    
+
     // Wait
     WGPUFutureWaitInfo waitInfo = { future, 0 };
     while (!mapCtx.done) {
@@ -224,13 +224,13 @@ TEST_F(WebGPUTest, BufferMappingWrite) {
 
     void* ptr = wgpuBufferGetMappedRange(buffer, 0, 64);
     ASSERT_NE(ptr, nullptr);
-    
+
     // Write data
     int* intPtr = (int*)ptr;
     *intPtr = 42;
 
     wgpuBufferUnmap(buffer);
-    
+
     // Check state (conceptually, via API check if available or failure to map again immediately)
     // Cleanup
     wgpuBufferRelease(buffer);
@@ -240,14 +240,14 @@ TEST_F(WebGPUTest, GLSLComputeMultiplication) {
     // 1. Create Data Buffer (Input/Output)
     const uint32_t elementCount = 64;
     const uint32_t bufferSize = elementCount * sizeof(uint32_t);
-    
+
     // Create staging buffer mapped at creation to upload initial data
     WGPUBufferDescriptor stagingDesc = {};
     stagingDesc.size = bufferSize;
     stagingDesc.usage = WGPUBufferUsage_CopySrc | WGPUBufferUsage_MapWrite;
     stagingDesc.mappedAtCreation = true;
     WGPUBuffer stagingBuffer = wgpuDeviceCreateBuffer(device, &stagingDesc);
-    
+
     uint32_t* initialData = (uint32_t*)wgpuBufferGetMappedRange(stagingBuffer, 0, bufferSize);
     for(uint32_t i=0; i<elementCount; ++i) initialData[i] = i;
     wgpuBufferUnmap(stagingBuffer);
@@ -263,7 +263,7 @@ TEST_F(WebGPUTest, GLSLComputeMultiplication) {
     wgpuCommandEncoderCopyBufferToBuffer(encoder, stagingBuffer, 0, storageBuffer, 0, bufferSize);
     WGPUCommandBuffer setupCmd = wgpuCommandEncoderFinish(encoder, nullptr);
     wgpuQueueSubmit(queue, 1, &setupCmd);
-    
+
     // Wait for queue (simple wait idle for test)
     wgpuQueueWaitIdle(queue);
     wgpuCommandBufferRelease(setupCmd);
@@ -275,7 +275,7 @@ TEST_F(WebGPUTest, GLSLComputeMultiplication) {
     const char* glslCode = R"(
         #version 450
         layout(local_size_x = 1) in;
-        
+
         layout(std430, set = 0, binding = 0) buffer Data {
             uint values[];
         } data;
@@ -321,7 +321,7 @@ TEST_F(WebGPUTest, GLSLComputeMultiplication) {
     pipeDesc.layout = pipelineLayout;
     pipeDesc.compute.module = shaderModule;
     pipeDesc.compute.entryPoint = { "main", 4 };
-    
+
     WGPUComputePipeline pipeline = wgpuDeviceCreateComputePipeline(device, &pipeDesc);
     ASSERT_NE(pipeline, nullptr);
 
@@ -342,7 +342,7 @@ TEST_F(WebGPUTest, GLSLComputeMultiplication) {
     encoder = wgpuDeviceCreateCommandEncoder(device, nullptr);
     WGPUComputePassDescriptor passDesc = {}; // Null timestamp writes
     WGPUComputePassEncoder pass = wgpuCommandEncoderBeginComputePass(encoder, &passDesc);
-    
+
     wgpuComputePassEncoderSetPipeline(pass, pipeline);
     wgpuComputePassEncoderSetBindGroup(pass, 0, bindGroup, 0, nullptr);
     wgpuComputePassEncoderDispatchWorkgroups(pass, elementCount, 1, 1);
@@ -365,20 +365,20 @@ TEST_F(WebGPUTest, GLSLComputeMultiplication) {
     encoder = wgpuDeviceCreateCommandEncoder(device, nullptr);
     wgpuCommandEncoderCopyBufferToBuffer(encoder, storageBuffer, 0, readBuffer, 0, bufferSize);
     cmd = wgpuCommandEncoderFinish(encoder, nullptr);
-    
+
     wgpuQueueSubmit(queue, 1, &cmd);
     wgpuCommandEncoderRelease(encoder);
-    
+
     // Intentionally defer releasing the cmd buffer
     // to check refcount validity
     ASSERT_EQ(cmd->refCount, 2);
-    
+
     for(uint32_t i = 0;i < framesInFlight;i++){
         wgpuDeviceTick(device);
     }
     ASSERT_EQ(cmd->refCount, 1);
     wgpuCommandBufferRelease(cmd);
-    
+
     // Map Async
     struct MapCtx { bool done = false; } mapCtx;
     auto mapCb = [](WGPUMapAsyncStatus, WGPUStringView, void* ud, void*) {
@@ -386,7 +386,7 @@ TEST_F(WebGPUTest, GLSLComputeMultiplication) {
     };
     WGPUBufferMapCallbackInfo mapCbInfo = { nullptr, WGPUCallbackMode_WaitAnyOnly, mapCb, &mapCtx, nullptr };
     WGPUFuture mapFut = wgpuBufferMapAsync(readBuffer, WGPUMapMode_Read, 0, bufferSize, mapCbInfo);
-    
+
     WGPUFutureWaitInfo fwi = { mapFut, 0 };
     while(!mapCtx.done) {
         wgpuInstanceWaitAny(instance, 1, &fwi, UINT64_MAX);
@@ -421,7 +421,7 @@ TEST_F(WebGPUTest, QueueWorkDone) {
         WGPUQueueWorkDoneStatus status;
     } workCtx;
 
-    auto workCallback = [](WGPUQueueWorkDoneStatus status, void* userdata, void* u2) {
+    auto workCallback = [](WGPUQueueWorkDoneStatus status, WGPUStringView, void* userdata, void* u2) {
         WorkCtx* ctx = (WorkCtx*)userdata;
         ctx->status = status;
         ctx->done = true;
@@ -433,7 +433,7 @@ TEST_F(WebGPUTest, QueueWorkDone) {
     cbInfo.mode = WGPUCallbackMode_WaitAnyOnly;
 
     WGPUFuture future = wgpuQueueOnSubmittedWorkDone(queue, cbInfo);
-    
+
     // Submit some dummy work to ensure queue progresses
     WGPUCommandEncoder encoder = wgpuDeviceCreateCommandEncoder(device, nullptr);
     WGPUCommandBuffer cmd = wgpuCommandEncoderFinish(encoder, nullptr);
@@ -459,10 +459,10 @@ TEST_F(WebGPUTest, BufferCopyRoundTrip) {
     srcDesc.usage = WGPUBufferUsage_MapWrite | WGPUBufferUsage_CopySrc;
     srcDesc.mappedAtCreation = true;
     srcDesc.label = { "SourceBuffer", 12 };
-    
+
     WGPUBuffer srcBuffer = wgpuDeviceCreateBuffer(device, &srcDesc);
     ASSERT_NE(srcBuffer, nullptr);
-    
+
     // Fill with pattern
     uint32_t* srcPtr = (uint32_t*)wgpuBufferGetMappedRange(srcBuffer, 0, dataSize);
     ASSERT_NE(srcPtr, nullptr);
@@ -470,39 +470,39 @@ TEST_F(WebGPUTest, BufferCopyRoundTrip) {
         srcPtr[i] = 0xCAFEBABE + i;
     }
     wgpuBufferUnmap(srcBuffer);
-    
+
     // 2. Create Intermediate Buffer: GPU only
     WGPUBufferDescriptor interDesc = {};
     interDesc.size = dataSize;
-    interDesc.usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_CopySrc; 
+    interDesc.usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_CopySrc;
     interDesc.mappedAtCreation = false;
     interDesc.label = { "IntermediateBuffer", 18 };
-    
+
     WGPUBuffer interBuffer = wgpuDeviceCreateBuffer(device, &interDesc);
     ASSERT_NE(interBuffer, nullptr);
-    
+
     // 3. Create Destination Buffer: Map Read capable
     WGPUBufferDescriptor dstDesc = {};
     dstDesc.size = dataSize;
     dstDesc.usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_MapRead;
     dstDesc.mappedAtCreation = false;
     dstDesc.label = { "DestBuffer", 10 };
-    
+
     WGPUBuffer dstBuffer = wgpuDeviceCreateBuffer(device, &dstDesc);
     ASSERT_NE(dstBuffer, nullptr);
-    
+
     // 4. Encode Copies
     WGPUCommandEncoder encoder = wgpuDeviceCreateCommandEncoder(device, nullptr);
-    
+
     // Source -> Intermediate
     wgpuCommandEncoderCopyBufferToBuffer(encoder, srcBuffer, 0, interBuffer, 0, dataSize);
-    
+
     // Intermediate -> Destination
     wgpuCommandEncoderCopyBufferToBuffer(encoder, interBuffer, 0, dstBuffer, 0, dataSize);
-    
+
     WGPUCommandBuffer cmd = wgpuCommandEncoderFinish(encoder, nullptr);
     ASSERT_NE(cmd, nullptr);
-    
+
     // Check RefCounts while command buffer is alive but not yet submitted (or just submitted).
     // Resources should be referenced by the CommandBuffer/ResourceUsage tracking.
     // Expected: 1 (User) + 1 (CommandBuffer/Encoder Tracking) = 2
@@ -512,48 +512,48 @@ TEST_F(WebGPUTest, BufferCopyRoundTrip) {
 
     // 5. Submit
     wgpuQueueSubmit(queue, 1, &cmd);
-    
+
     wgpuCommandEncoderRelease(encoder);
     wgpuCommandBufferRelease(cmd);
-    
+
     // After submission, CommandBuffer ref is gone, but Queue/FrameCache now holds them.
     // wgvk moves tracking to internal frame structures.
-    
+
     // 6. Map Async Destination
-    struct MapCtx { 
-        bool done = false; 
-        WGPUMapAsyncStatus status = WGPUMapAsyncStatus_Error; 
+    struct MapCtx {
+        bool done = false;
+        WGPUMapAsyncStatus status = WGPUMapAsyncStatus_Error;
     } mapCtx;
-    
+
     auto mapCb = [](WGPUMapAsyncStatus status, WGPUStringView, void* ud, void*) {
         auto* ctx = (MapCtx*)ud;
         ctx->status = status;
         ctx->done = true;
     };
-    
+
     WGPUBufferMapCallbackInfo cbInfo = { nullptr, WGPUCallbackMode_WaitAnyOnly, mapCb, &mapCtx, nullptr };
-    
+
     // This implicitly synchronizes access to dstBuffer
     WGPUFuture future = wgpuBufferMapAsync(dstBuffer, WGPUMapMode_Read, 0, dataSize, cbInfo);
-    
+
     // Wait for callback
     WGPUFutureWaitInfo waitInfo = { future, 0 };
     while (!mapCtx.done) {
         wgpuInstanceWaitAny(instance, 1, &waitInfo, UINT64_MAX);
     }
-    
+
     ASSERT_EQ(mapCtx.status, WGPUMapAsyncStatus_Success);
-    
+
     // 7. Verify Data
     const uint32_t* dstPtr = (const uint32_t*)wgpuBufferGetConstMappedRange(dstBuffer, 0, dataSize);
     ASSERT_NE(dstPtr, nullptr);
-    
+
     for(uint32_t i = 0; i < count; ++i) {
         EXPECT_EQ(dstPtr[i], 0xCAFEBABE + i) << "Mismatch at index " << i;
     }
-    
+
     wgpuBufferUnmap(dstBuffer);
-    
+
     // 8. Tick device to cycle frame resources and release internal refs
     // Submit dummy work to move the ring buffer if necessary, or just tick.
     // Based on previous discussion, we might need a dummy submission to prevent the wait-on-zero-sem bug
@@ -562,12 +562,12 @@ TEST_F(WebGPUTest, BufferCopyRoundTrip) {
     for(uint32_t i = 0;i < framesInFlight;i++){
         wgpuDeviceTick(device); // Frame N -> N+1
     }
-    
+
     // Verify RefCounts have dropped back to 1 (only our local variables holding them)
     EXPECT_EQ(srcBuffer->refCount, 1);
     EXPECT_EQ(interBuffer->refCount, 1);
     EXPECT_EQ(dstBuffer->refCount, 1);
-    
+
     // Cleanup
     wgpuBufferRelease(srcBuffer);
     wgpuBufferRelease(interBuffer);
@@ -578,7 +578,7 @@ TEST_F(WebGPUTest, RenderPassClearToRed) {
     // 64 pixels width * 4 bytes = 256 bytes per row (WebGPU requirement aligned)
     const uint32_t width = 64;
     const uint32_t height = 64;
-    const uint32_t bytesPerRow = 256; 
+    const uint32_t bytesPerRow = 256;
     const size_t bufferSize = bytesPerRow * height;
 
     // 1. Create Texture (Render Attachment + Copy Source)
@@ -590,12 +590,12 @@ TEST_F(WebGPUTest, RenderPassClearToRed) {
     texDesc.sampleCount = 1;
     texDesc.dimension = WGPUTextureDimension_2D;
     texDesc.label = { "ColorAttachment", 15 };
-    
+
     WGPUTexture texture = wgpuDeviceCreateTexture(device, &texDesc);
     ASSERT_NE(texture, nullptr);
 
     // 2. Create Default View
-    WGPUTextureView view = wgpuTextureCreateView(texture, nullptr); 
+    WGPUTextureView view = wgpuTextureCreateView(texture, nullptr);
     ASSERT_NE(view, nullptr);
 
     // 3. Create Readback Buffer
@@ -604,24 +604,24 @@ TEST_F(WebGPUTest, RenderPassClearToRed) {
     bufDesc.usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_MapRead;
     bufDesc.mappedAtCreation = false;
     bufDesc.label = { "ReadbackBuffer", 14 };
-    
+
     WGPUBuffer buffer = wgpuDeviceCreateBuffer(device, &bufDesc);
     ASSERT_NE(buffer, nullptr);
 
     // 4. Encode Render Pass
     WGPUCommandEncoder encoder = wgpuDeviceCreateCommandEncoder(device, nullptr);
-    
+
     WGPURenderPassColorAttachment colorAtt = {};
     colorAtt.view = view;
     colorAtt.loadOp = WGPULoadOp_Clear;
     colorAtt.storeOp = WGPUStoreOp_Store;
     colorAtt.clearValue = {1.0, 0.0, 0.0, 1.0}; // RED
-    
+
     WGPURenderPassDescriptor rpDesc = {};
     rpDesc.colorAttachmentCount = 1;
     rpDesc.colorAttachments = &colorAtt;
     rpDesc.depthStencilAttachment = nullptr; // No depth
-    
+
     WGPURenderPassEncoder rp = wgpuCommandEncoderBeginRenderPass(encoder, &rpDesc);
     wgpuRenderPassEncoderEnd(rp);
     wgpuRenderPassEncoderRelease(rp);
@@ -647,14 +647,14 @@ TEST_F(WebGPUTest, RenderPassClearToRed) {
 
     // 6. Submit
     wgpuQueueSubmit(queue, 1, &cmd);
-    
+
     // RefCount Check:
-    // Texture should be held by: 
+    // Texture should be held by:
     // 1. User (test variable)
     // 2. View (internal ref)
     // 3. Command Buffer/Resource Usage tracking (pending execution)
-    EXPECT_GE(texture->refCount, 3); 
-    
+    EXPECT_GE(texture->refCount, 3);
+
     wgpuCommandBufferRelease(cmd);
 
     // 7. Map Async & Verify
@@ -664,9 +664,9 @@ TEST_F(WebGPUTest, RenderPassClearToRed) {
         ((MapCtx*)ud)->done = true;
     };
     WGPUBufferMapCallbackInfo cbInfo = { nullptr, WGPUCallbackMode_WaitAnyOnly, mapCb, &mapCtx, nullptr };
-    
+
     WGPUFuture mapFut = wgpuBufferMapAsync(buffer, WGPUMapMode_Read, 0, bufferSize, cbInfo);
-    
+
     WGPUFutureWaitInfo fwi = { mapFut, 0 };
     while(!mapCtx.done) {
         wgpuInstanceWaitAny(instance, 1, &fwi, UINT64_MAX);
@@ -698,7 +698,7 @@ TEST_F(WebGPUTest, RenderPassClearToRed) {
     for(uint32_t i = 0;i < framesInFlight;i++){
         wgpuDeviceTick(device);
     }
-    
+
     // Texture should now only be held by User(1) + View(1) = 2
     EXPECT_EQ(texture->refCount, 2);
     // View held by User(1)
@@ -707,10 +707,10 @@ TEST_F(WebGPUTest, RenderPassClearToRed) {
     EXPECT_EQ(buffer->refCount, 1);
 
     wgpuTextureViewRelease(view);
-    
+
     // View released its hold on Texture, now RefCount = 1
     EXPECT_EQ(texture->refCount, 1);
-    
+
     wgpuTextureRelease(texture);
     wgpuBufferRelease(buffer);
 }
@@ -718,7 +718,7 @@ TEST_F(WebGPUTest, RenderPassClearToRed) {
 TEST_F(WebGPUTest, RenderPassTriangleDraw) {
     const uint32_t width = 64;
     const uint32_t height = 64;
-    const uint32_t bytesPerRow = 256; 
+    const uint32_t bytesPerRow = 256;
     const size_t bufferSize = bytesPerRow * height;
 
     // 1. Setup Shaders
@@ -834,7 +834,7 @@ TEST_F(WebGPUTest, RenderPassTriangleDraw) {
     WGPUTexelCopyTextureInfo srcInfo = {};
     srcInfo.texture = texture;
     srcInfo.aspect = WGPUTextureAspect_All;
-    
+
     WGPUTexelCopyBufferInfo dstInfo = {};
     dstInfo.buffer = readBuffer;
     dstInfo.layout.bytesPerRow = bytesPerRow;
@@ -856,7 +856,7 @@ TEST_F(WebGPUTest, RenderPassTriangleDraw) {
         ((MapCtx*)ud)->done = true;
     };
     WGPUBufferMapCallbackInfo cbInfo = { nullptr, WGPUCallbackMode_WaitAnyOnly, mapCb, &mapCtx, nullptr };
-    
+
     WGPUFuture future = wgpuBufferMapAsync(readBuffer, WGPUMapMode_Read, 0, bufferSize, cbInfo);
     WGPUFutureWaitInfo fwi = { .future = future, .completed = 0 };
 
@@ -877,7 +877,7 @@ TEST_F(WebGPUTest, RenderPassTriangleDraw) {
 
     // Check Inside Triangle (Green)
     // This region is definitely covered by TL-BL-BR triangle (x <= y roughly)
-    checkPixel(10, 50, 0, 255, 0); 
+    checkPixel(10, 50, 0, 255, 0);
     checkPixel(0, 63, 0, 255, 0);
 
     // Check Outside Triangle (Blue Clear Color)
@@ -1247,7 +1247,7 @@ TEST_F(WebGPUTest, LimitsGetAndSet) {
     // Get limits from adapter
     WGPULimits adapterLimits = {0};
     ASSERT_EQ(wgpuAdapterGetLimits(adapter, &adapterLimits), WGPUStatus_Success) << "Failed to get adapter limits";
-    
+
     // Verify that core limits are reasonable (non-zero, within expected ranges)
     EXPECT_GT(adapterLimits.maxTextureDimension1D, 0u);
     EXPECT_GT(adapterLimits.maxTextureDimension2D, 0u);
@@ -1256,9 +1256,9 @@ TEST_F(WebGPUTest, LimitsGetAndSet) {
     EXPECT_GE(adapterLimits.maxBindGroups, 4u); // WebGPU spec minimum is 4
     EXPECT_GT(adapterLimits.maxVertexBuffers, 0u);
     EXPECT_GT(adapterLimits.maxComputeInvocationsPerWorkgroup, 0u);
-    
+
     // Verify alignment limits are power of 2
-    EXPECT_EQ(adapterLimits.minUniformBufferOffsetAlignment & (adapterLimits.minUniformBufferOffsetAlignment - 1), 0u) 
+    EXPECT_EQ(adapterLimits.minUniformBufferOffsetAlignment & (adapterLimits.minUniformBufferOffsetAlignment - 1), 0u)
         << "minUniformBufferOffsetAlignment should be power of 2";
     EXPECT_EQ(adapterLimits.minStorageBufferOffsetAlignment & (adapterLimits.minStorageBufferOffsetAlignment - 1), 0u)
         << "minStorageBufferOffsetAlignment should be power of 2";
@@ -1268,36 +1268,36 @@ TEST_F(WebGPUTest, LimitsGetAndSet) {
         WGPUDevice device = nullptr;
         bool done = false;
     } deviceCtx;
-    
+
     auto deviceCallback = [](WGPURequestDeviceStatus status, WGPUDevice dev, WGPUStringView msg, void* userdata, void* userdata2) {
         DeviceCtx* ctx = (DeviceCtx*)userdata;
         ctx->device = dev;
         ctx->done = true;
     };
-    
+
     WGPULimits requiredLimits = adapterLimits;
     requiredLimits.maxTextureDimension2D = 4096;
     requiredLimits.maxBindGroups = 6;
-    
+
     WGPUDeviceDescriptor deviceDesc3 = {0};
     deviceDesc3.requiredLimits = &requiredLimits;
-    
+
     WGPURequestDeviceCallbackInfo cbInfo = { nullptr, WGPUCallbackMode_WaitAnyOnly, deviceCallback, &deviceCtx, nullptr };
     WGPUFuture future = wgpuAdapterRequestDevice(adapter, &deviceDesc3, cbInfo);
     WGPUFutureWaitInfo fwi = { .future = future, .completed = 0 };
-    
+
     while(!deviceCtx.done) {
         wgpuInstanceWaitAny(instance, 1, &fwi, UINT32_MAX);
     }
-    
+
     ASSERT_NE(deviceCtx.device, nullptr) << "Failed to create device with required limits";
     WGPUDevice device3 = deviceCtx.device;
-    
+
     WGPULimits deviceLimits3 = {0};
     wgpuDeviceGetLimits(device3, &deviceLimits3);
     EXPECT_EQ(deviceLimits3.maxTextureDimension2D, 4096u) << "Device should return requested maxTextureDimension2D";
     EXPECT_EQ(deviceLimits3.maxBindGroups, 6u) << "Device should return requested maxBindGroups";
-    
+
     // TODO: Test that creating textures larger than maxTextureDimension2D fails
     // Currently not enforced, but should be:
     // WGPUTextureDescriptor texDesc = {0};
@@ -1306,7 +1306,7 @@ TEST_F(WebGPUTest, LimitsGetAndSet) {
     // texDesc.usage = WGPUTextureUsage_CopyDst;
     // WGPUTexture tex = wgpuDeviceCreateTexture(device3, &texDesc);
     // EXPECT_EQ(tex, nullptr) << "Should fail to create texture exceeding limits";
-    
+
     wgpuDeviceRelease(device3);
 }
 
@@ -1822,7 +1822,7 @@ TEST_F(WebGPUTest, FenceSignalAndWait) {
         WGPUQueueWorkDoneStatus status = WGPUQueueWorkDoneStatus_Error;
     } ctx;
 
-    auto cb = [](WGPUQueueWorkDoneStatus status, void* ud, void*) {
+    auto cb = [](WGPUQueueWorkDoneStatus status, WGPUStringView, void* ud, void*) {
         WorkCtx* c = (WorkCtx*)ud;
         c->status = status;
         c->done = true;
@@ -1882,7 +1882,7 @@ TEST_F(WebGPUTest, WaitAny_SingleFuture_WorkDone) {
         WGPUQueueWorkDoneStatus status = WGPUQueueWorkDoneStatus_Error;
     } ctx;
 
-    auto cb = [](WGPUQueueWorkDoneStatus status, void* ud, void*) {
+    auto cb = [](WGPUQueueWorkDoneStatus status, WGPUStringView, void* ud, void*) {
         WorkCtx* c = (WorkCtx*)ud;
         c->status = status;
         c->done = true;
@@ -2009,7 +2009,7 @@ TEST_F(WebGPUTest, Edge_QueueWorkDone_NoSubmission) {
         WGPUQueueWorkDoneStatus status = WGPUQueueWorkDoneStatus_Error;
     } ctx;
 
-    auto cb = [](WGPUQueueWorkDoneStatus status, void* ud, void*) {
+    auto cb = [](WGPUQueueWorkDoneStatus status, WGPUStringView, void* ud, void*) {
         WorkCtx* c = (WorkCtx*)ud;
         c->status = status;
         c->done = true;


### PR DESCRIPTION
## Summary
Match the WebGPU spec:
- `WGPUDepthStencilState.depthWriteEnabled`: `WGPUBool32` → `WGPUOptionalBool`
- `WGPUQueueWorkDoneCallback`: add the missing `WGPUStringView message`
- `WGPUDeviceLostCallbackInfo.mode`: `int` → `WGPUCallbackMode`