### PR TITLE
Add docs to build.zig and make it more flexible and reliable across platforms

### DIFF
--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -55,6 +55,11 @@ jobs:
 
       # TODO: Add tests and examples
       - name: Build Lib for ${{ matrix.target }}
+        if: runner.os == 'Linux'
+        run: zig build --search-prefix /usr -Dtarget=${{ matrix.target }} -Doptimize=ReleaseFast --verbose
+
+      - name: Build Lib for ${{ matrix.target }}
+        if: runner.os != 'Linux'
         run: zig build -Dtarget=${{ matrix.target }} -Doptimize=ReleaseFast --verbose
 
       - name: Build Lib for x86_64 windows msvc
@@ -63,11 +68,11 @@ jobs:
 
       - name: Cross Compile
         if: runner.os == 'Linux'
-        run: zig build -Doptimize=ReleaseFast all --verbose
+        run: zig build --search-prefix /usr -Doptimize=ReleaseFast all --verbose
 
       - name: Build Examples Linux
         if: runner.os == 'Linux'
-        run: zig build -Doptimize=ReleaseFast examples --verbose
+        run: zig build --search-prefix /usr -Doptimize=ReleaseFast examples --verbose
 
       - name: Build iOS Targets
         if: runner.os == 'macOS'
@@ -76,9 +81,9 @@ jobs:
           zig build --sysroot "$(xcrun --sdk iphonesimulator --show-sdk-path)" -Dtarget=aarch64-ios-simulator -Doptimize=ReleaseFast --verbose
           zig build --sysroot "$(xcrun --sdk iphonesimulator --show-sdk-path)" -Dtarget=x86_64-ios-simulator -Doptimize=ReleaseFast --verbose
 
-      - name: Build Examples (non-Linux)
+      - name: Build Examples (macOS)
         if: runner.os == 'macOS'
-        run: zig build -Doptimize=ReleaseFast examples --verbose
+        run: zig build --search-prefix "$(brew --prefix)" -Doptimize=ReleaseFast examples --verbose
 
       - name: Build Examples (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -38,6 +38,13 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y libwayland-dev libx11-dev libxrandr-dev libglfw3-dev
+          # Curate a search prefix: --search-prefix /usr also exposes system
+          # vulkan/libc headers that clash with Zig + the vendored Vulkan headers.
+          mkdir -p .ci-prefix/include
+          ln -s /usr/include/X11 .ci-prefix/include/X11
+          ln -s /usr/include/GLFW .ci-prefix/include/GLFW
+          for f in /usr/include/wayland*.h; do ln -sf "$f" .ci-prefix/include/; done
+          ln -s /usr/lib/x86_64-linux-gnu .ci-prefix/lib
 
       - name: Install macOS deps
         if: runner.os == 'macOS'
@@ -56,7 +63,7 @@ jobs:
       # TODO: Add tests and examples
       - name: Build Lib for ${{ matrix.target }}
         if: runner.os == 'Linux'
-        run: zig build --search-prefix /usr -Dtarget=${{ matrix.target }} -Doptimize=ReleaseFast --verbose
+        run: zig build --search-prefix .ci-prefix -Dtarget=${{ matrix.target }} -Doptimize=ReleaseFast --verbose
 
       - name: Build Lib for ${{ matrix.target }}
         if: runner.os != 'Linux'
@@ -68,11 +75,11 @@ jobs:
 
       - name: Cross Compile
         if: runner.os == 'Linux'
-        run: zig build --search-prefix /usr -Doptimize=ReleaseFast all --verbose
+        run: zig build --search-prefix .ci-prefix -Doptimize=ReleaseFast all --verbose
 
       - name: Build Examples Linux
         if: runner.os == 'Linux'
-        run: zig build --search-prefix /usr -Doptimize=ReleaseFast examples --verbose
+        run: zig build --search-prefix .ci-prefix -Doptimize=ReleaseFast examples --verbose
 
       - name: Build iOS Targets
         if: runner.os == 'macOS'

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -37,14 +37,21 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt update
-          sudo apt install -y libwayland-dev libx11-dev libxrandr-dev libglfw3-dev
+          # Xcursor for RGFW; Xi/Xinerama/xkbcommon for building GLFW 3.4.
+          # Ubuntu's libglfw3-dev is 3.3.x (no glfwGetPlatform); match Windows CI on 3.4.
+          sudo apt install -y libwayland-dev libx11-dev libxrandr-dev libxcursor-dev \
+            libxinerama-dev libxi-dev libxkbcommon-dev
+          git clone --depth 1 --branch 3.4 https://github.com/glfw/glfw.git
+          cmake -S glfw -B glfw-build \
+            -DGLFW_BUILD_EXAMPLES=OFF -DGLFW_BUILD_TESTS=OFF -DGLFW_BUILD_DOCS=OFF \
+            -DBUILD_SHARED_LIBS=ON \
+            -DCMAKE_INSTALL_PREFIX="$PWD/.ci-prefix"
+          cmake --build glfw-build --target install -j"$(nproc)"
           # Curate a search prefix: --search-prefix /usr also exposes system
           # vulkan/libc headers that clash with Zig + the vendored Vulkan headers.
-          mkdir -p .ci-prefix/include
-          ln -s /usr/include/X11 .ci-prefix/include/X11
-          ln -s /usr/include/GLFW .ci-prefix/include/GLFW
+          # GLFW 3.4 is already installed into .ci-prefix; only symlink X11/Wayland.
+          ln -sfn /usr/include/X11 .ci-prefix/include/X11
           for f in /usr/include/wayland*.h; do ln -sf "$f" .ci-prefix/include/; done
-          ln -s /usr/lib/x86_64-linux-gnu .ci-prefix/lib
 
       - name: Install macOS deps
         if: runner.os == 'macOS'

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -33,6 +33,26 @@ jobs:
         with:
           version: 0.16.0
 
+      - name: Install Linux deps
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
+          sudo apt install -y libwayland-dev libx11-dev libxrandr-dev libglfw3-dev
+
+      - name: Install macOS deps
+        if: runner.os == 'macOS'
+        run: brew install glfw
+
+      - name: Install Windows GLFW
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri https://github.com/glfw/glfw/releases/download/3.4/glfw-3.4.bin.WIN64.zip -OutFile glfw.zip
+          Expand-Archive glfw.zip -DestinationPath .
+          New-Item -ItemType Directory -Force -Path glfw-prefix/include, glfw-prefix/lib | Out-Null
+          Copy-Item -Recurse glfw-3.4.bin.WIN64/include/* glfw-prefix/include/
+          Copy-Item glfw-3.4.bin.WIN64/lib-mingw-w64/* glfw-prefix/lib/
+
       # TODO: Add tests and examples
       - name: Build Lib for ${{ matrix.target }}
         run: zig build -Dtarget=${{ matrix.target }} -Doptimize=ReleaseFast --verbose
@@ -47,18 +67,19 @@ jobs:
 
       - name: Build Examples Linux
         if: runner.os == 'Linux'
-        run: |
-          sudo apt update
-          sudo apt install -y libwayland-dev libx11-dev libxrandr-dev
-          zig build -Doptimize=ReleaseFast examples --verbose
+        run: zig build -Doptimize=ReleaseFast examples --verbose
 
       - name: Build iOS Targets
         if: runner.os == 'macOS'
         run: |
-          zig build -Dtarget=aarch64-ios -Doptimize=ReleaseFast --verbose
-          zig build -Dtarget=aarch64-ios-simulator -Doptimize=ReleaseFast --verbose
-          zig build -Dtarget=x86_64-ios-simulator -Doptimize=ReleaseFast --verbose
+          zig build --sysroot "$(xcrun --sdk iphoneos --show-sdk-path)" -Dtarget=aarch64-ios -Doptimize=ReleaseFast --verbose
+          zig build --sysroot "$(xcrun --sdk iphonesimulator --show-sdk-path)" -Dtarget=aarch64-ios-simulator -Doptimize=ReleaseFast --verbose
+          zig build --sysroot "$(xcrun --sdk iphonesimulator --show-sdk-path)" -Dtarget=x86_64-ios-simulator -Doptimize=ReleaseFast --verbose
 
       - name: Build Examples (non-Linux)
-        if: runner.os != 'Linux'
+        if: runner.os == 'macOS'
         run: zig build -Doptimize=ReleaseFast examples --verbose
+
+      - name: Build Examples (Windows)
+        if: runner.os == 'Windows'
+        run: zig build --search-prefix ./glfw-prefix -Doptimize=ReleaseFast examples --verbose

--- a/build.zig
+++ b/build.zig
@@ -180,6 +180,13 @@ fn buildLib1(b: *std.Build, options: WgvkOptions) !*std.Build.Step.Compile {
         },
         .ios => {
             wgvk_mod.addCMacro("SUPPORT_METAL_SURFACE", "1");
+            // When the user/CI passes --sysroot (e.g. iphoneos SDK), wire it into
+            // the C module. Zig does not automatically add $sysroot/usr/include.
+            if (b.sysroot) |sysroot| {
+                wgvk_mod.addSystemIncludePath(.{ .cwd_relative = b.pathJoin(&.{ sysroot, "usr/include" }) });
+                wgvk_mod.addSystemFrameworkPath(.{ .cwd_relative = b.pathJoin(&.{ sysroot, "System/Library/Frameworks" }) });
+                wgvk_mod.addLibraryPath(.{ .cwd_relative = b.pathJoin(&.{ sysroot, "usr/lib" }) });
+            }
         },
         else => {
             const is_android = options.target.result.abi.isAndroid();

--- a/build.zig
+++ b/build.zig
@@ -297,6 +297,10 @@ fn buildExample(
         .linux => {
             const is_android = options.target.result.abi.isAndroid();
             if (!is_android and options.enable_x11) {
+                if (b.lazyDependency("x11_headers", .{})) |x11| {
+                    // rgfw requires X11 headers
+                    example_exe.root_module.addIncludePath(x11.path("."));
+                }
                 example_exe.root_module.linkSystemLibrary("X11", .{});
                 example_exe.root_module.linkSystemLibrary("Xrandr", .{});
             }

--- a/build.zig
+++ b/build.zig
@@ -16,9 +16,32 @@
 //!             // other optional features
 //!             .use_vma = use_vma, // use GPUOpen's VMA allocator (Requires and links libc++)
 //!             .support_drm = support_drm, // support Direct Rendering Infrastructure Surfaces (Linux)
-//!             .enable_x11 = enable_x11, // enable X11 support
+//!             .enable_x11 = enable_x11, // enable X11 support (Requires system libX11-dev. Enable on Linux only.)
 //!             .enable_wayland = enable_wayland, // enable Wayland support (Requires system libwayland-client. Enable on Linux only.)
 //!         });
+//!
+//!         switch (target.result.os.tag) {
+//!             .windows => {
+//!                 exe.root_module.linkSystemLibrary("gdi32", .{});
+//!             },
+//!             .macos => {
+//!                 // see below for more details on how to cross-compile to macos
+//!                 exe.root_module.linkFramework("Foundation", .{});
+//!                 exe.root_module.linkFramework("Metal", .{});
+//!                 exe.root_module.linkFramework("Cocoa", .{});
+//!             },
+//!             .linux => {
+//!                 const is_android = target.result.abi.isAndroid();
+//!                 if (!is_android and enable_x11) {
+//!                     exe.root_module.linkSystemLibrary("X11", .{});
+//!                     exe.root_module.linkSystemLibrary("Xrandr", .{});
+//!                 }
+//!                 if (!is_android and enable_wayland) {
+//!                     exe.root_module.linkSystemLibrary("wayland-client", .{});
+//!                 }
+//!             },
+//!             else => return error.UnsupportedPlatform,
+//!         }
 //!
 //!         exe.root_module.linkLibrary(wgvk_lib);
 //!     }
@@ -39,21 +62,15 @@
 //!     fn build(b: *std.Build) !void {
 //!         // your exe + wgvk_lib build steps
 //!         if (target.result.os.tag == .macos) {
+//!             // put this block next to the macos configuration in the previous step
 //!             const xcode_frameworks = b.dependency("xcode_frameworks", .{});
 //!
 //!             b.addSystemFrameworkPath(xcode_frameworks.path("Frameworks"));
 //!             b.addSystemIncludePath(xcode_frameworks.path("include"));
 //!             b.addLibraryPath(xcode_frameworks.path("lib"));
-//!
-//!             exe.root_module.linkFramework("Metal", .{});
-//!             exe.root_module.linkFramework("Cocoa", .{});
 //!         }
 //!     }
 //!     ```
-//!
-//! ## Cross-compiling to Windows
-//! If you are cross-compiling to Windows, you have to use the -gnu abi.
-//! You can only use the -msvc abi from a Windows host.
 const std = @import("std");
 
 pub fn build(b: *std.Build) !void {
@@ -113,6 +130,9 @@ pub fn build(b: *std.Build) !void {
     };
     for (build_targets) |t| {
         const resolved_target = b.resolveTargetQuery(t);
+        // skip iOS targets on non macOS hosts
+        if (resolved_target.result.os.tag == .ios and b.graph.host.result.os.tag != .macos) continue;
+
         const lib = try buildLib1(b, .{
             .target = resolved_target,
             .optimize = optimize,
@@ -191,7 +211,7 @@ fn buildLib1(b: *std.Build, options: WgvkOptions) !*std.Build.Step.Compile {
 
             if (!is_android and options.enable_x11) if (b.lazyDependency("x11_headers", .{})) |x11| {
                 wgvk_mod.addCMacro("SUPPORT_XLIB_SURFACE", "1");
-                wgvk_mod.linkLibrary(x11.artifact("x11-headers"));
+                wgvk_mod.addIncludePath(x11.path("."));
             };
             if (options.enable_wayland) if (b.lazyDependency("wayland_headers", .{})) |wayland| {
                 wgvk_mod.addCMacro("SUPPORT_WAYLAND_SURFACE", "1");
@@ -254,7 +274,6 @@ fn buildExample(
 
     switch (options.target.result.os.tag) {
         .windows => {
-            example_exe.root_module.addCMacro("SUPPORT_WIN32_SURFACE", "1");
             example_exe.root_module.linkSystemLibrary("gdi32", .{});
         },
         .macos => {
@@ -263,23 +282,19 @@ fn buildExample(
                 example_exe.root_module.addSystemIncludePath(frameworks.path("include"));
                 example_exe.root_module.addLibraryPath(frameworks.path("lib"));
             }
-            example_exe.root_module.addCMacro("SUPPORT_METAL_SURFACE", "1");
+            example_exe.root_module.linkFramework("Foundation", .{});
             example_exe.root_module.linkFramework("Metal", .{});
             example_exe.root_module.linkFramework("Cocoa", .{});
         },
         .linux => {
             const is_android = options.target.result.abi.isAndroid();
-            if (!is_android and options.enable_x11) if (b.lazyDependency("x11_headers", .{})) |x11| {
-                example_exe.root_module.addCMacro("SUPPORT_XLIB_SURFACE", "1");
-                example_exe.root_module.linkLibrary(x11.artifact("x11-headers"));
+            if (!is_android and options.enable_x11) {
                 example_exe.root_module.linkSystemLibrary("X11", .{});
                 example_exe.root_module.linkSystemLibrary("Xrandr", .{});
-            };
-            if (!is_android and options.enable_wayland) if (b.lazyDependency("wayland_headers", .{})) |wayland| {
-                example_exe.root_module.addCMacro("SUPPORT_WAYLAND_SURFACE", "1");
-                example_exe.root_module.addIncludePath(wayland.path("wayland"));
+            }
+            if (!is_android and options.enable_wayland) {
                 example_exe.root_module.linkSystemLibrary("wayland-client", .{});
-            };
+            }
         },
         .ios => {
             return error.UnsupportedPlatform;

--- a/build.zig
+++ b/build.zig
@@ -200,8 +200,16 @@ fn buildLib1(b: *std.Build, options: WgvkOptions) !*std.Build.Step.Compile {
         .windows => {
             wgvk_mod.addCMacro("SUPPORT_WIN32_SURFACE", "1");
         },
-        .macos, .ios => {
+        .macos => {
             wgvk_mod.addCMacro("SUPPORT_METAL_SURFACE", "1");
+        },
+        .ios => {
+            wgvk_mod.addCMacro("SUPPORT_METAL_SURFACE", "1");
+            if (b.lazyDependency("xcode_frameworks", .{})) |frameworks| {
+                wgvk_mod.addSystemFrameworkPath(frameworks.path("Frameworks"));
+                wgvk_mod.addSystemIncludePath(frameworks.path("include"));
+                wgvk_mod.addLibraryPath(frameworks.path("lib"));
+            }
         },
         else => {
             const is_android = options.target.result.abi.isAndroid();

--- a/build.zig
+++ b/build.zig
@@ -46,31 +46,6 @@
 //!         exe.root_module.linkLibrary(wgvk_lib);
 //!     }
 //!     ```
-//!
-//! ## Cross-compiling to MacOS
-//! If you are cross-compiling to MacOS, you will need xcode_frameworks to be
-//! added to your module search path. This can be done by adding the following.
-//!
-//! > NOTE: you might need to tweak a few things depending on your setup.
-//!
-//! 1. Install xcode_frameworks
-//!     ```bash
-//!     zig fetch --save=xcode_frameworks https://code.hexops.org/hexops/xcode-frameworks
-//!     ```
-//! 2. Add the following to your build.zig file:
-//!     ```zig
-//!     fn build(b: *std.Build) !void {
-//!         // your exe + wgvk_lib build steps
-//!         if (target.result.os.tag == .macos) {
-//!             // put this block next to the macos configuration in the previous step
-//!             const xcode_frameworks = b.dependency("xcode_frameworks", .{});
-//!
-//!             b.addSystemFrameworkPath(xcode_frameworks.path("Frameworks"));
-//!             b.addSystemIncludePath(xcode_frameworks.path("include"));
-//!             b.addLibraryPath(xcode_frameworks.path("lib"));
-//!         }
-//!     }
-//!     ```
 const std = @import("std");
 
 pub fn build(b: *std.Build) !void {
@@ -205,11 +180,6 @@ fn buildLib1(b: *std.Build, options: WgvkOptions) !*std.Build.Step.Compile {
         },
         .ios => {
             wgvk_mod.addCMacro("SUPPORT_METAL_SURFACE", "1");
-            if (b.lazyDependency("xcode_frameworks", .{})) |frameworks| {
-                wgvk_mod.addSystemFrameworkPath(frameworks.path("Frameworks"));
-                wgvk_mod.addSystemIncludePath(frameworks.path("include"));
-                wgvk_mod.addLibraryPath(frameworks.path("lib"));
-            }
         },
         else => {
             const is_android = options.target.result.abi.isAndroid();
@@ -217,14 +187,12 @@ fn buildLib1(b: *std.Build, options: WgvkOptions) !*std.Build.Step.Compile {
                 wgvk_mod.addCMacro("SUPPORT_DRM_SURFACE", "1");
             }
 
-            if (!is_android and options.enable_x11) if (b.lazyDependency("x11_headers", .{})) |x11| {
+            if (!is_android and options.enable_x11) {
                 wgvk_mod.addCMacro("SUPPORT_XLIB_SURFACE", "1");
-                wgvk_mod.addIncludePath(x11.path("."));
-            };
-            if (options.enable_wayland) if (b.lazyDependency("wayland_headers", .{})) |wayland| {
+            }
+            if (!is_android and options.enable_wayland) {
                 wgvk_mod.addCMacro("SUPPORT_WAYLAND_SURFACE", "1");
-                wgvk_mod.addIncludePath(wayland.path("wayland"));
-            };
+            }
         },
     }
 
@@ -270,14 +238,7 @@ fn buildExample(
     example_exe.root_module.linkLibrary(wgvk_lib);
 
     if (std.mem.eql(u8, example, "glfw_surface")) {
-        if (b.lazyDependency("glfw", .{
-            .target = options.target,
-            .optimize = options.optimize,
-            .x11 = options.enable_x11,
-            .wayland = options.enable_wayland,
-        })) |glfw| {
-            example_exe.root_module.linkLibrary(glfw.artifact("glfw"));
-        }
+        example_exe.root_module.linkSystemLibrary("glfw", .{});
     }
 
     switch (options.target.result.os.tag) {
@@ -285,11 +246,6 @@ fn buildExample(
             example_exe.root_module.linkSystemLibrary("gdi32", .{});
         },
         .macos => {
-            if (b.lazyDependency("xcode_frameworks", .{})) |frameworks| {
-                example_exe.root_module.addSystemFrameworkPath(frameworks.path("Frameworks"));
-                example_exe.root_module.addSystemIncludePath(frameworks.path("include"));
-                example_exe.root_module.addLibraryPath(frameworks.path("lib"));
-            }
             example_exe.root_module.linkFramework("Foundation", .{});
             example_exe.root_module.linkFramework("Metal", .{});
             example_exe.root_module.linkFramework("Cocoa", .{});
@@ -297,10 +253,6 @@ fn buildExample(
         .linux => {
             const is_android = options.target.result.abi.isAndroid();
             if (!is_android and options.enable_x11) {
-                if (b.lazyDependency("x11_headers", .{})) |x11| {
-                    // rgfw requires X11 headers
-                    example_exe.root_module.addIncludePath(x11.path("."));
-                }
                 example_exe.root_module.linkSystemLibrary("X11", .{});
                 example_exe.root_module.linkSystemLibrary("Xrandr", .{});
             }

--- a/build.zig
+++ b/build.zig
@@ -238,7 +238,9 @@ fn buildExample(
     example_exe.root_module.linkLibrary(wgvk_lib);
 
     if (std.mem.eql(u8, example, "glfw_surface")) {
-        example_exe.root_module.linkSystemLibrary("glfw", .{});
+        // Linux/macOS ship libglfw; Windows prebuilts use glfw3.
+        const glfw_name = if (options.target.result.os.tag == .windows) "glfw3" else "glfw";
+        example_exe.root_module.linkSystemLibrary(glfw_name, .{});
     }
 
     switch (options.target.result.os.tag) {

--- a/build.zig
+++ b/build.zig
@@ -1,3 +1,59 @@
+//! # Usage
+//! The intended way to use this library is as follows:
+//! 1. Add this library to your project as a dependency.
+//!     ```bash
+//!     zig fetch --save git+https://github.com/manuel5975p/WGVK#<commit-or-tag>
+//!     ```
+//! 2. Add the following to your build.zig file:
+//!     ```zig
+//!     const wgvk = @import("WGVK"); // the name of the dependency as defined in your build.zig.zon file
+//!
+//!     pub fn build(b: *std.Build) !void {
+//!         // other build steps
+//!         const wgvk_lib = wgvk.buildLib(b, .{
+//!             .target = target,
+//!             .optimize = optimize,
+//!             // other optional features
+//!             .use_vma = use_vma, // use GPUOpen's VMA allocator (Requires and links libc++)
+//!             .support_drm = support_drm, // support Direct Rendering Infrastructure Surfaces (Linux)
+//!             .enable_x11 = enable_x11, // enable X11 support
+//!             .enable_wayland = enable_wayland, // enable Wayland support (Requires system libwayland-client. Enable on Linux only.)
+//!         });
+//!
+//!         exe.root_module.linkLibrary(wgvk_lib);
+//!     }
+//!     ```
+//!
+//! ## Cross-compiling to MacOS
+//! If you are cross-compiling to MacOS, you will need xcode_frameworks to be
+//! added to your module search path. This can be done by adding the following.
+//!
+//! > NOTE: you might need to tweak a few things depending on your setup.
+//!
+//! 1. Install xcode_frameworks
+//!     ```bash
+//!     zig fetch --save=xcode_frameworks https://code.hexops.org/hexops/xcode-frameworks
+//!     ```
+//! 2. Add the following to your build.zig file:
+//!     ```zig
+//!     fn build(b: *std.Build) !void {
+//!         // your exe + wgvk_lib build steps
+//!         if (target.result.os.tag == .macos) {
+//!             const xcode_frameworks = b.dependency("xcode_frameworks", .{});
+//!
+//!             b.addSystemFrameworkPath(xcode_frameworks.path("Frameworks"));
+//!             b.addSystemIncludePath(xcode_frameworks.path("include"));
+//!             b.addLibraryPath(xcode_frameworks.path("lib"));
+//!
+//!             exe.root_module.linkFramework("Metal", .{});
+//!             exe.root_module.linkFramework("Cocoa", .{});
+//!         }
+//!     }
+//!     ```
+//!
+//! ## Cross-compiling to Windows
+//! If you are cross-compiling to Windows, you have to use the -gnu abi.
+//! You can only use the -msvc abi from a Windows host.
 const std = @import("std");
 
 pub fn build(b: *std.Build) !void {
@@ -125,14 +181,7 @@ fn buildLib1(b: *std.Build, options: WgvkOptions) !*std.Build.Step.Compile {
             wgvk_mod.addCMacro("SUPPORT_WIN32_SURFACE", "1");
         },
         .macos, .ios => {
-            if (b.lazyDependency("xcode_frameworks", .{})) |frameworks| {
-                wgvk_mod.addSystemFrameworkPath(frameworks.path("Frameworks"));
-                wgvk_mod.addSystemIncludePath(frameworks.path("include"));
-                wgvk_mod.addLibraryPath(frameworks.path("lib"));
-            }
             wgvk_mod.addCMacro("SUPPORT_METAL_SURFACE", "1");
-            wgvk_mod.linkFramework("Metal", .{});
-            wgvk_mod.linkFramework("QuartzCore", .{});
         },
         else => {
             const is_android = options.target.result.abi.isAndroid();
@@ -192,18 +241,21 @@ fn buildExample(
     });
     example_exe.root_module.linkLibrary(wgvk_lib);
 
-    if (b.lazyDependency("glfw", .{
-        .target = options.target,
-        .optimize = options.optimize,
-        .x11 = options.enable_x11,
-        .wayland = options.enable_wayland,
-    })) |glfw| {
-        example_exe.root_module.linkLibrary(glfw.artifact("glfw"));
+    if (std.mem.eql(u8, example, "glfw_surface")) {
+        if (b.lazyDependency("glfw", .{
+            .target = options.target,
+            .optimize = options.optimize,
+            .x11 = options.enable_x11,
+            .wayland = options.enable_wayland,
+        })) |glfw| {
+            example_exe.root_module.linkLibrary(glfw.artifact("glfw"));
+        }
     }
 
     switch (options.target.result.os.tag) {
         .windows => {
             example_exe.root_module.addCMacro("SUPPORT_WIN32_SURFACE", "1");
+            example_exe.root_module.linkSystemLibrary("gdi32", .{});
         },
         .macos => {
             if (b.lazyDependency("xcode_frameworks", .{})) |frameworks| {
@@ -213,11 +265,7 @@ fn buildExample(
             }
             example_exe.root_module.addCMacro("SUPPORT_METAL_SURFACE", "1");
             example_exe.root_module.linkFramework("Metal", .{});
-            example_exe.root_module.linkFramework("QuartzCore", .{});
-            example_exe.root_module.linkFramework("CoreVideo", .{});
             example_exe.root_module.linkFramework("Cocoa", .{});
-            example_exe.root_module.linkFramework("OpenGL", .{});
-            example_exe.root_module.linkFramework("IOKit", .{});
         },
         .linux => {
             const is_android = options.target.result.abi.isAndroid();

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,26 +4,5 @@
     .minimum_zig_version = "0.15.1",
     .paths = .{""},
     .fingerprint = 0xfa41188e5ce82b6,
-    .dependencies = .{
-        .xcode_frameworks = .{
-            .url = "git+https://github.com/shreyassanthu77/xcode-frameworks.git#62f660e82e4eddb5007cb4cf06a6d3d31237f05e",
-            .hash = "N-V-__8AAMikhQnOIqoH0uy5aepJKs8Zy0VqznnW3n94VSZN",
-            .lazy = true,
-        },
-        .x11_headers = .{
-            .url = "git+https://code.hexops.org/hexops/x11-headers#ea933d71f13816b25bf8533e44e105aed8fe4ba7",
-            .hash = "N-V-__8AAIxIRwBTt3m8YLYIjDLGc2J6d1X6v2kdQRUZJQSk",
-            .lazy = true,
-        },
-        .wayland_headers = .{
-            .url = "https://github.com/Batres3/wayland-headers/archive/190b247ebc85546752dcf0255070fe835e2262b8.tar.gz",
-            .hash = "N-V-__8AALvXCgD7AaGEzoGpZFSnomVUd9osYPJN3P4jxxj9",
-            .lazy = true,
-        },
-        .glfw = .{
-            .url = "git+https://github.com/shreyassanthu77/glfw-zig.git#3d4b046938a3508e7dfe3f5de5ce6b4b450d6895",
-            .hash = "glfw-0.0.0-R5AeUpIJGgBBORlw5iznqTvDb1QW_nDCejzyMlqIbIJQ",
-            .lazy = true,
-        },
-    },
+    .dependencies = .{},
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -11,8 +11,8 @@
             .lazy = true,
         },
         .x11_headers = .{
-            .url = "https://github.com/Batres3/x11-headers/archive/d85c0aed3f1ecc138c994ae00bb745c4cba9e574.zip",
-            .hash = "N-V-__8AAIyUQgB3B5VLoRxZ6OIasJUeaUSD3c6U2Tjhe7TZ",
+            .url = "git+https://code.hexops.org/hexops/x11-headers#ea933d71f13816b25bf8533e44e105aed8fe4ba7",
+            .hash = "N-V-__8AAIxIRwBTt3m8YLYIjDLGc2J6d1X6v2kdQRUZJQSk",
             .lazy = true,
         },
         .wayland_headers = .{


### PR DESCRIPTION
- Added docs to the build.zig file to show how to use it
- Removed linking system libraries for the library builds.
- Removed all dependencies and make wayland and x11 linking user problem instead of pre providing headers
- Do not auto link libraries on behalf of users to make it more flexible to link in custom versions/stubs etc